### PR TITLE
Fix fallback rich text toolbar selection and popover cleanup

### DIFF
--- a/src/components/common/RichTextEditor.tsx
+++ b/src/components/common/RichTextEditor.tsx
@@ -502,6 +502,15 @@ const RichTextEditor = React.forwardRef<
     updateFormatState();
   }, [showVariableDropdown, updateVariableDropdownPosition, updateFormatState]);
 
+  const handleToolbarMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      event.preventDefault();
+      focusEditor();
+      saveSelection();
+    },
+    [focusEditor, saveSelection]
+  );
+
   const applyLink = useCallback(() => {
     if (!linkUrl.trim() || !linkLabel.trim()) return;
     focusEditor();
@@ -576,7 +585,7 @@ const RichTextEditor = React.forwardRef<
             <Button
               type="text"
               icon={<BoldOutlined />}
-              onMouseDown={(event) => event.preventDefault()}
+              onMouseDown={handleToolbarMouseDown}
               onClick={() => applyCommand("bold")}
               className={clsx(styles.toolbarButton, {
                 [styles.toolbarButtonActive]: formatState.bold,
@@ -588,7 +597,7 @@ const RichTextEditor = React.forwardRef<
             <Button
               type="text"
               icon={<ItalicOutlined />}
-              onMouseDown={(event) => event.preventDefault()}
+              onMouseDown={handleToolbarMouseDown}
               onClick={() => applyCommand("italic")}
               className={clsx(styles.toolbarButton, {
                 [styles.toolbarButtonActive]: formatState.italic,
@@ -600,7 +609,7 @@ const RichTextEditor = React.forwardRef<
             <Button
               type="text"
               icon={<UnderlineOutlined />}
-              onMouseDown={(event) => event.preventDefault()}
+              onMouseDown={handleToolbarMouseDown}
               onClick={() => applyCommand("underline")}
               className={clsx(styles.toolbarButton, {
                 [styles.toolbarButtonActive]: formatState.underline,
@@ -612,7 +621,7 @@ const RichTextEditor = React.forwardRef<
             <Button
               type="text"
               icon={<StrikethroughOutlined />}
-              onMouseDown={(event) => event.preventDefault()}
+              onMouseDown={handleToolbarMouseDown}
               onClick={() => applyCommand("strikeThrough")}
               className={clsx(styles.toolbarButton, {
                 [styles.toolbarButtonActive]: formatState.strikeThrough,
@@ -665,7 +674,7 @@ const RichTextEditor = React.forwardRef<
               <Button
                 type="text"
                 icon={<LinkOutlined />}
-                onMouseDown={(event) => event.preventDefault()}
+                onMouseDown={handleToolbarMouseDown}
                 className={styles.toolbarButton}
                 size="small"
               />
@@ -676,7 +685,7 @@ const RichTextEditor = React.forwardRef<
             <Button
               type="text"
               icon={<AimOutlined />}
-              onMouseDown={(event) => event.preventDefault()}
+              onMouseDown={handleToolbarMouseDown}
               onClick={() => {
                 setTimeout(() => {
                   focusEditor();

--- a/src/components/voiceflow/PropertiesPanel.tsx
+++ b/src/components/voiceflow/PropertiesPanel.tsx
@@ -3821,7 +3821,7 @@ export default function PropertiesPanel({
         <div className={styles.buttonsFallbackList}>
           <Popover
             trigger={["click"]}
-            destroyTooltipOnHide
+            destroyOnHidden
             placement="left"
             overlayClassName={styles.buttonsFallbackPopover}
             open={fallbackPopover === "noMatch"}
@@ -3855,7 +3855,7 @@ export default function PropertiesPanel({
 
           <Popover
             trigger={["click"]}
-            destroyTooltipOnHide
+            destroyOnHidden
             placement="left"
             overlayClassName={styles.buttonsFallbackPopover}
             open={fallbackPopover === "noReply"}


### PR DESCRIPTION
## Summary
- replace deprecated `destroyTooltipOnHide` usage in the fallback popovers with the Ant Design 5 `destroyOnHidden` prop
- ensure the rich text toolbar keeps focus on the editor so bold/italic/underline/strikethrough actions reliably apply to the current selection

## Testing
- npm run lint (fails: Invalid option '--ext' - unsupported with flat config)


------
https://chatgpt.com/codex/tasks/task_e_68deb72a26f48327bd30f29e11903814