### PR TITLE
Improve rich text selection handling and link popover

### DIFF
--- a/src/components/common/RichTextEditor.module.scss
+++ b/src/components/common/RichTextEditor.module.scss
@@ -119,12 +119,20 @@
   outline: none;
 }
 
-.linkPopover :global(.ant-popover-inner) {
+.linkPopoverPanel {
+  position: absolute;
+  z-index: 2147483647;
+  background: #fff;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
   padding: 16px;
 }
 
 .linkPopoverContent {
-  width: 260px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .variableTag,

--- a/src/components/voiceflow/PropertiesPanel.tsx
+++ b/src/components/voiceflow/PropertiesPanel.tsx
@@ -3821,7 +3821,7 @@ export default function PropertiesPanel({
         <div className={styles.buttonsFallbackList}>
           <Popover
             trigger={["click"]}
-            destroyTooltipOnHide
+            destroyOnHidden
             placement="left"
             overlayClassName={styles.buttonsFallbackPopover}
             open={fallbackPopover === "noMatch"}
@@ -3855,7 +3855,7 @@ export default function PropertiesPanel({
 
           <Popover
             trigger={["click"]}
-            destroyTooltipOnHide
+            destroyOnHidden
             placement="left"
             overlayClassName={styles.buttonsFallbackPopover}
             open={fallbackPopover === "noReply"}


### PR DESCRIPTION
## Summary
- keep the saved selection in sync with the editor and reuse it when querying command states so the formatting buttons stay accurate after interacting with the toolbar or popovers
- rebuild the link popover with a manual portal that preserves the selection, keeps the form open while typing, and lets users update existing anchors
- add styling for the custom link popover container to match the editor

## Testing
- npm run lint *(fails: Invalid option '--ext' – unsupported with flat config)*
- npm run build *(fails: repository is missing Next.js dependencies/types referenced by other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68deb72a26f48327bd30f29e11903814