### PR TITLE
Add reprompt generation controls and path labels

### DIFF
--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1349,6 +1349,7 @@
   }
 }
 
+
 .buttonsNodeEditor {
   display: flex;
   flex-direction: column;
@@ -1377,22 +1378,19 @@
   color: #0f172a;
 }
 
-.buttonsNodeMatchRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
+.buttonsNodeAddAnother {
+  margin-top: 4px;
+  align-self: stretch;
+  height: 36px;
+  border-radius: 10px;
+  font-weight: 600;
 
-.buttonsNodeMatchLabel {
-  font-size: 13px;
-  color: #475569;
-  font-weight: 500;
-}
-
-.buttonsNodeMatchSelect {
-  min-width: 160px;
-  flex: 1;
+  &:disabled {
+    color: #94a3b8 !important;
+    border-color: #e2e8f0 !important;
+    background: #f8fafc !important;
+    box-shadow: none;
+  }
 }
 
 .buttonsNodeDivider {

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1618,12 +1618,13 @@
 }
 
 .buttonsRepromptAdd {
-  align-self: flex-start;
   border-radius: 10px;
   border: 1px dashed #d1d5db !important;
   background: #f8fafc;
   font-weight: 600;
   color: #334155;
+  height: 40px;
+  flex: 1;
 
   &:hover,
   &:focus {
@@ -1631,6 +1632,91 @@
     color: #2563eb;
     background: #eef4ff;
   }
+}
+
+.buttonsRepromptActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.buttonsRepromptGenerate {
+  flex: 1;
+  height: 40px;
+  border-radius: 12px !important;
+  background: linear-gradient(135deg, #2563eb, #4338ca);
+  color: #ffffff;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  box-shadow: 0 10px 18px rgba(37, 99, 235, 0.2);
+  border: none;
+
+  &:hover,
+  &:focus {
+    background: linear-gradient(135deg, #1d4ed8, #3730a3);
+    color: #ffffff;
+  }
+}
+
+.buttonsRepromptGenerateIcon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.buttonsRepromptGenerateCaret {
+  font-size: 12px;
+}
+
+.buttonsRepromptGenerateMenu {
+  :global(.ant-dropdown-menu) {
+    border-radius: 12px;
+    padding: 8px 0;
+  }
+
+  :global(.ant-dropdown-menu-item) {
+    font-weight: 500;
+  }
+}
+
+.buttonsFollowPathRow {
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.buttonsFollowPathLabel {
+  font-size: 13px;
+  font-weight: 500;
+  color: #334155;
+}
+
+.buttonsPathLabelCard {
+  margin-top: 12px;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.buttonsPathLabelTitle {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #64748b;
+  letter-spacing: 0.04em;
+}
+
+.buttonsPathLabelInput {
+  border-radius: 10px;
 }
 
 .buttonsLinkPopover {

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1100,7 +1100,6 @@
   font-size: 12px;
   font-weight: 600;
   color: #4b5563;
-  text-transform: uppercase;
   letter-spacing: 0.4px;
   margin: 12px 0 8px;
 }
@@ -1709,27 +1708,75 @@
   color: #334155;
 }
 
-.buttonsPathLabelCard {
+.buttonsPathLabelTrigger {
   margin-top: 12px;
-  background: #f1f5f9;
-  border: 1px solid #e2e8f0;
+  width: 100%;
+  border: 1px solid #dbe4f0;
   border-radius: 14px;
+  background: #f8fbff;
   padding: 12px 14px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  appearance: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    border-color: #9ab4ec;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.12);
+    outline: none;
+  }
 }
 
-.buttonsPathLabelTitle {
+.buttonsPathLabelTriggerTitle {
   font-size: 12px;
   font-weight: 600;
-  text-transform: uppercase;
-  color: #64748b;
-  letter-spacing: 0.04em;
+  color: #475569;
+  letter-spacing: 0.02em;
+}
+
+.buttonsPathLabelTriggerValue {
+  font-size: 13px;
+  font-weight: 500;
+  color: #0f172a;
+}
+
+.buttonsPathLabelPopover {
+  :global(.ant-popover-inner) {
+    border-radius: 16px;
+    padding: 16px;
+    width: 260px;
+  }
+
+  :global(.ant-popover-arrow) {
+    display: none;
+  }
+}
+
+.buttonsPathLabelPopoverContent {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.buttonsPathLabelPopoverTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
 }
 
 .buttonsPathLabelInput {
   border-radius: 10px;
+}
+
+.buttonsPathLabelDone {
+  border-radius: 12px;
+  height: 36px;
+  font-weight: 600;
 }
 
 .buttonsLinkPopover {

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1351,13 +1351,25 @@
 }
 
 .buttonsNodeEditor {
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 12px;
   background: #fff;
+  border-radius: 16px;
+  padding: 16px;
+  width: 320px;
+}
+
+.buttonsNodePopover {
+  :global(.ant-popover-inner) {
+    border-radius: 20px;
+    padding: 0;
+    box-shadow: 0 20px 36px rgba(15, 23, 42, 0.18);
+  }
+
+  :global(.ant-popover-arrow) {
+    display: none;
+  }
 }
 
 .buttonsNodeEditorTitle {
@@ -1381,6 +1393,7 @@
 
 .buttonsNodeMatchSelect {
   min-width: 160px;
+  flex: 1;
 }
 
 .buttonsNodeDivider {

--- a/src/components/voiceflow/PropertiesPanel.tsx
+++ b/src/components/voiceflow/PropertiesPanel.tsx
@@ -3432,13 +3432,39 @@ export default function PropertiesPanel({
       });
     };
 
-    const addButton = () => {
+    const addButton = (afterId?: string) => {
+      if (buttonsStateRef.current.length >= 10) {
+        return;
+      }
+
       const newButton: ButtonsNodeButton = {
         id: generateButtonId(),
         label: "",
         matchType: "exact",
       };
-      const next = [...buttonsStateRef.current, newButton];
+
+      const current = buttonsStateRef.current;
+      const trimmed = afterId
+        ? current.map((button) =>
+            button.id === afterId
+              ? { ...button, label: button.label.trim() }
+              : button
+          )
+        : current.slice();
+
+      const insertIndex = afterId
+        ? trimmed.findIndex((button) => button.id === afterId)
+        : -1;
+
+      const next =
+        afterId && insertIndex >= 0
+          ? [
+              ...trimmed.slice(0, insertIndex + 1),
+              newButton,
+              ...trimmed.slice(insertIndex + 1),
+            ]
+          : [...trimmed, newButton];
+
       setButtonsState(next);
       buttonsStateRef.current = next;
       persistButtons(next);
@@ -3506,10 +3532,7 @@ export default function PropertiesPanel({
               type="default"
               className={styles.buttonsNodeAddAnother}
               disabled={isAddAnotherDisabled}
-              onClick={() => {
-                persistButtons();
-                addButton();
-              }}
+              onClick={() => addButton(button.id)}
             >
               Add another
             </Button>
@@ -4006,7 +4029,7 @@ export default function PropertiesPanel({
           <Button
             icon={<PlusOutlined />}
             type="text"
-            onClick={addButton}
+            onClick={() => addButton()}
             disabled={buttonsState.length >= 10}
             className={styles.buttonsNodeAdd}
           />

--- a/src/components/voiceflow/PropertiesPanel.tsx
+++ b/src/components/voiceflow/PropertiesPanel.tsx
@@ -303,7 +303,7 @@ const actionsEqual = (
   });
 };
 
-const buttonsEqual = (
+const buttonsEqual1 = (
   left: CardButton | null,
   right: CardButton | null
 ): boolean => {

--- a/src/components/voiceflow/PropertiesPanel.tsx
+++ b/src/components/voiceflow/PropertiesPanel.tsx
@@ -3471,47 +3471,52 @@ export default function PropertiesPanel({
         });
       };
 
-    const renderButtonEditor = (button: ButtonsNodeButton) => (
-      <div className={styles.buttonsNodeEditor}>
-        <Typography.Text className={styles.buttonsNodeEditorTitle}>
-          Button
-        </Typography.Text>
-        <ValueInput
-          ref={(instance) => {
-            if (instance) {
-              buttonLabelRefs.current[button.id] = instance;
-            } else {
-              delete buttonLabelRefs.current[button.id];
+    const renderButtonEditor = (button: ButtonsNodeButton) => {
+      const canRenderAddAnother = buttonsStateRef.current.length < 10;
+      const isAddAnotherDisabled = button.label.trim().length === 0;
+
+      return (
+        <div className={styles.buttonsNodeEditor}>
+          <Typography.Text className={styles.buttonsNodeEditorTitle}>
+            Button
+          </Typography.Text>
+          <ValueInput
+            ref={(instance) => {
+              if (instance) {
+                buttonLabelRefs.current[button.id] = instance;
+              } else {
+                delete buttonLabelRefs.current[button.id];
+              }
+            }}
+            value={button.label}
+            onChange={(value) =>
+              updateButtonLocal(button.id, { label: value })
             }
-          }}
-          value={button.label}
-          onChange={(value) =>
-            updateButtonLocal(button.id, { label: value })
-          }
-          onBlur={() => persistButtons()}
-          onPressEnter={() => {
-            persistButtons();
-            setActiveButtonId(null);
-          }}
-          placeholder="Enter button label or {variable}"
-          size="large"
-        />
-        <div className={styles.buttonsNodeMatchRow}>
-          <span className={styles.buttonsNodeMatchLabel}>Match type</span>
-          <Select
-            value={button.matchType}
-            onChange={(value: ButtonMatchType) =>
-              updateButtonLocal(button.id, { matchType: value }, { persist: true })
-            }
-            options={[
-              { value: "exact", label: "Match exact" },
-              { value: "any", label: "Match any" },
-            ]}
-            className={styles.buttonsNodeMatchSelect}
+            onBlur={() => persistButtons()}
+            onPressEnter={() => {
+              persistButtons();
+              setActiveButtonId(null);
+            }}
+            placeholder="Enter button label or {variable}"
+            size="large"
           />
+          {canRenderAddAnother && (
+            <Button
+              block
+              type="default"
+              className={styles.buttonsNodeAddAnother}
+              disabled={isAddAnotherDisabled}
+              onClick={() => {
+                persistButtons();
+                addButton();
+              }}
+            >
+              Add another
+            </Button>
+          )}
         </div>
-      </div>
-    );
+      );
+    };
 
     const rawNoMatch = selectedNode.data.noMatch as
       | ButtonsFallbackConfig
@@ -4015,7 +4020,7 @@ export default function PropertiesPanel({
           )}
           {buttonsState.map((button) => {
             const isActive = activeButtonId === button.id;
-            const displayLabel = button.label.trim() || "New button (inactive)";
+            const displayLabel = button.label.trim() || "Add button label";
             return (
               <Popover
                 key={button.id}

--- a/src/components/voiceflow/nodes/ButtonsNode.module.scss
+++ b/src/components/voiceflow/nodes/ButtonsNode.module.scss
@@ -127,3 +127,9 @@
     background: #52c41a;
   }
 }
+
+.handleInner {
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/voiceflow/nodes/ButtonsNode.module.scss
+++ b/src/components/voiceflow/nodes/ButtonsNode.module.scss
@@ -1,21 +1,11 @@
+@use "./variables" as *;
+
 .node {
-  position: relative;
-  width: 240px;
+  @extend %node-base;
   background: #ffffff;
-  border: 1px solid #e2e8f0;
   border-radius: 12px;
+  border: 1px solid #e2e8f0;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
-  overflow: visible;
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease;
-  font-family:
-    "Inter",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Roboto,
-    sans-serif;
 
   &.selected {
     border-color: #14b8a6;
@@ -43,7 +33,7 @@
 .node__buttonList {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .node__empty {
@@ -63,17 +53,10 @@
   gap: 12px;
   border: 1px solid #e2e8f0;
   border-radius: 12px;
-  background: #f8fafc;
-  padding: 12px;
-  padding-right: 48px;
-}
-
-.node__buttonContent {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  flex: 1;
-  min-width: 0;
+  background: #ffffff;
+  padding: 10px 14px;
+  min-height: 38px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
 }
 
 .node__buttonLabel {
@@ -83,72 +66,13 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1;
 }
 
-.node__matchTag {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  border-radius: 999px;
-  padding: 2px 10px;
-}
-
-.node__matchTagExact {
-  background: #e0f2fe;
-  color: #0369a1;
-  border: 1px solid #bae6fd;
-}
-
-.node__matchTagAny {
-  background: #fce7f3;
-  color: #9d174d;
-  border: 1px solid #fbcfe8;
-}
-
-.node__connector {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 999px;
-  background: #e2e8f0;
-  color: #475569;
-  font-size: 12px;
-  flex-shrink: 0;
-  margin-left: auto;
-}
-
-.handleWrapper {
-  position: absolute;
-  top: 50%;
-  right: -12px;
-  transform: translateY(-50%);
-  width: 24px;
-  height: 24px;
-  border-radius: 999px;
-  background: #ecfdf5;
-  border: 1px solid #bbf7d0;
-  box-shadow: 0 1px 2px rgba(16, 185, 129, 0.18);
-  flex-shrink: 0;
-}
-
-.handleWrapper::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 12px;
-  height: 12px;
-  border-radius: 999px;
-  background: #10b981;
-  border: 2px solid #ffffff;
-  box-shadow: 0 0 0 1px rgba(16, 185, 129, 0.25);
+.node__buttonLabelPlaceholder {
+  color: #94a3b8;
+  font-weight: 500;
+  font-style: italic;
 }
 
 .node__more {
@@ -180,34 +104,24 @@
 
 .handle {
   position: absolute;
-  top: -6px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 22px;
-  height: 22px;
-  border-radius: 999px;
-  background: #14b8a6;
-  box-shadow:
-    0 0 0 2px #ffffff,
-    0 4px 8px rgba(20, 184, 166, 0.3);
-}
-
-.handle::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 12px;
-  height: 12px;
-  border-radius: 999px;
-  background: #0f766e;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
   border: 2px solid #ffffff;
-  box-shadow: 0 0 0 1px rgba(15, 118, 110, 0.25);
-}
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
+  background: #14b8a6;
+  pointer-events: auto;
 
-.handleInner {
-  width: 100%;
-  height: 100%;
-  opacity: 0;
+  &--top {
+    top: -5px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  &--button {
+    top: 50%;
+    right: -6px;
+    transform: translateY(-50%);
+    background: #34d399;
+  }
 }

--- a/src/components/voiceflow/nodes/ButtonsNode.module.scss
+++ b/src/components/voiceflow/nodes/ButtonsNode.module.scss
@@ -55,10 +55,17 @@
   border-radius: 12px;
   background: #ffffff;
   padding: 8px 14px;
-  padding-right: 28px;
+  padding-right: 24px;
   min-height: 36px;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
   overflow: visible;
+}
+
+.node__buttonHandle {
+  position: absolute;
+  top: 50%;
+  right: -12px;
+  transform: translateY(-50%);
 }
 
 .node__buttonLabel {
@@ -108,9 +115,10 @@
   position: absolute;
   width: 10px;
   height: 10px;
-  border-radius: 50%;
-  border: 2px solid #ffffff;
-  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
+  border-radius: 5px;
+  border: 2px solid white;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+  z-index: 1;
   background: #ec4899;
   pointer-events: auto;
 
@@ -121,9 +129,6 @@
   }
 
   &--button {
-    top: 50%;
-    right: -6px;
-    transform: translateY(-50%);
     background: #52c41a;
   }
 }

--- a/src/components/voiceflow/nodes/ButtonsNode.module.scss
+++ b/src/components/voiceflow/nodes/ButtonsNode.module.scss
@@ -54,9 +54,11 @@
   border: 1px solid #e2e8f0;
   border-radius: 12px;
   background: #ffffff;
-  padding: 10px 14px;
-  min-height: 38px;
+  padding: 8px 14px;
+  padding-right: 28px;
+  min-height: 36px;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  overflow: visible;
 }
 
 .node__buttonLabel {
@@ -109,7 +111,7 @@
   border-radius: 50%;
   border: 2px solid #ffffff;
   box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
-  background: #14b8a6;
+  background: #ec4899;
   pointer-events: auto;
 
   &--top {
@@ -122,6 +124,6 @@
     top: 50%;
     right: -6px;
     transform: translateY(-50%);
-    background: #34d399;
+    background: #52c41a;
   }
 }

--- a/src/components/voiceflow/nodes/ButtonsNode.tsx
+++ b/src/components/voiceflow/nodes/ButtonsNode.tsx
@@ -19,6 +19,7 @@ interface ButtonsFallbackConfig {
   reprompts?: string[];
   inactivityTimeout?: number;
   followPath?: boolean;
+  pathLabel?: string;
 }
 
 interface ButtonsNodeData {

--- a/src/components/voiceflow/nodes/ButtonsNode.tsx
+++ b/src/components/voiceflow/nodes/ButtonsNode.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Handle, Position, NodeProps } from "reactflow";
-import { AppstoreOutlined, ArrowRightOutlined } from "@ant-design/icons";
+import { AppstoreOutlined } from "@ant-design/icons";
 import { useAppDispatch } from "../../../store/hooks";
 import { updateNode } from "../../../store/slices/workflowSlice";
 import NodeHeader from "./shared/NodeHeader";
@@ -148,35 +148,26 @@ export default function ButtonsNode({
           {buttonsToRender.length === 0 ? (
             <div className={styles.node__empty}>No buttons configured yet</div>
           ) : (
-            buttonsToRender.map((button, index) => (
-              <div key={button.id || index} className={styles.node__buttonRow}>
-                <div className={styles.node__buttonContent}>
-                  <span className={styles.node__buttonLabel}>
-                    {button.label || `Button ${index + 1}`}
-                  </span>
+            buttonsToRender.map((button, index) => {
+              const label = button.label.trim();
+              return (
+                <div key={button.id || index} className={styles.node__buttonRow}>
                   <span
-                    className={`${styles.node__matchTag} ${
-                      button.matchType === "any"
-                        ? styles.node__matchTagAny
-                        : styles.node__matchTagExact
+                    className={`${styles.node__buttonLabel} ${
+                      label ? "" : styles.node__buttonLabelPlaceholder
                     }`}
                   >
-                    {button.matchType === "any" ? "Match any" : "Match exact"}
+                    {label || "Add button label"}
                   </span>
-                </div>
-                <span className={styles.node__connector}>
-                  <ArrowRightOutlined />
-                </span>
-                <div className={styles.handleWrapper}>
                   <Handle
                     type="source"
                     position={Position.Right}
                     id={`button-${button.id}`}
-                    className={styles.handleInner}
+                    className={`${styles.handle} ${styles["handle--button"]}`}
                   />
                 </div>
-              </div>
-            ))
+              );
+            })
           )}
           {remainingButtons > 0 && (
             <div className={styles.node__more}>+{remainingButtons} more</div>
@@ -200,13 +191,11 @@ export default function ButtonsNode({
         )}
       </div>
 
-      <div className={`${styles.handle} ${styles["handle--top"]}`}>
-        <Handle
-          type="target"
-          position={Position.Top}
-          className={styles.handleInner}
-        />
-      </div>
+      <Handle
+        type="target"
+        position={Position.Top}
+        className={`${styles.handle} ${styles["handle--top"]}`}
+      />
     </div>
   );
 }

--- a/src/components/voiceflow/nodes/ButtonsNode.tsx
+++ b/src/components/voiceflow/nodes/ButtonsNode.tsx
@@ -151,7 +151,10 @@ export default function ButtonsNode({
             buttonsToRender.map((button, index) => {
               const label = button.label.trim();
               return (
-                <div key={button.id || index} className={styles.node__buttonRow}>
+                <div
+                  key={button.id || index}
+                  className={styles.node__buttonRow}
+                >
                   <span
                     className={`${styles.node__buttonLabel} ${
                       label ? "" : styles.node__buttonLabelPlaceholder
@@ -159,15 +162,17 @@ export default function ButtonsNode({
                   >
                     {label || "Add button label"}
                   </span>
-                  <div
-                    className={`${styles.handle} ${styles["handle--button"]}`}
-                  >
-                    <Handle
-                      type="source"
-                      position={Position.Right}
-                      id={`button-${button.id}`}
-                      className={styles.handleInner}
-                    />
+                  <div className={styles.node__buttonHandle}>
+                    <div
+                      className={`${styles.handle} ${styles["handle--button"]}`}
+                    >
+                      <Handle
+                        type="source"
+                        position={Position.Right}
+                        id={`button-${button.id}`}
+                        className={styles.handleInner}
+                      />
+                    </div>
                   </div>
                 </div>
               );

--- a/src/components/voiceflow/nodes/ButtonsNode.tsx
+++ b/src/components/voiceflow/nodes/ButtonsNode.tsx
@@ -159,12 +159,16 @@ export default function ButtonsNode({
                   >
                     {label || "Add button label"}
                   </span>
-                  <Handle
-                    type="source"
-                    position={Position.Right}
-                    id={`button-${button.id}`}
+                  <div
                     className={`${styles.handle} ${styles["handle--button"]}`}
-                  />
+                  >
+                    <Handle
+                      type="source"
+                      position={Position.Right}
+                      id={`button-${button.id}`}
+                      className={styles.handleInner}
+                    />
+                  </div>
                 </div>
               );
             })
@@ -191,11 +195,13 @@ export default function ButtonsNode({
         )}
       </div>
 
-      <Handle
-        type="target"
-        position={Position.Top}
-        className={`${styles.handle} ${styles["handle--top"]}`}
-      />
+      <div className={`${styles.handle} ${styles["handle--top"]}`}>
+        <Handle
+          type="target"
+          position={Position.Top}
+          className={styles.handleInner}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a Generate dropdown to the reprompt editor so users can quickly insert 1, 3, or 5 reprompt entries
- surface the follow-path toggle for both fallbacks and show an inline path label editor when enabled
- extend the fallback config typings and styles to support the new controls

## Testing
- npm run lint *(fails: Invalid option '--ext' when using eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dec043dba48327a610972b3779bc25