### PR TITLE
Add intent picker and choice configuration support

### DIFF
--- a/src/components/common/EntityPicker.tsx
+++ b/src/components/common/EntityPicker.tsx
@@ -1,0 +1,104 @@
+import React, { useMemo, useState } from "react";
+import { Select, Input, Button, Divider, Typography } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import { addEntity } from "../../store/slices/entitiesSlice";
+
+interface EntityPickerProps {
+  value?: string;
+  onChange?: (value?: string) => void;
+  placeholder?: string;
+  allowClear?: boolean;
+  size?: "small" | "middle" | "large";
+  disabled?: boolean;
+  className?: string;
+}
+
+const EntityPicker: React.FC<EntityPickerProps> = ({
+  value,
+  onChange,
+  placeholder = "Select entity",
+  allowClear = true,
+  size = "middle",
+  disabled,
+  className,
+}) => {
+  const dispatch = useAppDispatch();
+  const entities = useAppSelector((state) => state.entities.list);
+  const [open, setOpen] = useState(false);
+  const [newEntityName, setNewEntityName] = useState("");
+
+  const options = useMemo(
+    () => entities.map((entity) => ({ label: entity, value: entity })),
+    [entities]
+  );
+
+  const commitChange = (next?: string) => {
+    if (onChange) {
+      onChange(next);
+    }
+  };
+
+  const handleCreateEntity = () => {
+    const trimmed = newEntityName.trim();
+    if (!trimmed) return;
+    dispatch(addEntity(trimmed));
+    commitChange(trimmed);
+    setNewEntityName("");
+    setOpen(false);
+  };
+
+  return (
+    <Select
+      showSearch
+      size={size}
+      value={value || undefined}
+      placeholder={placeholder}
+      allowClear={allowClear}
+      disabled={disabled}
+      options={options}
+      onChange={(nextValue) => commitChange(nextValue)}
+      onClear={() => commitChange(undefined)}
+      open={open}
+      onDropdownVisibleChange={setOpen}
+      dropdownRender={(menu) => (
+        <div>
+          {menu}
+          <Divider style={{ margin: "8px 0" }} />
+          <div style={{ display: "flex", gap: 8, padding: "0 8px 8px" }}>
+            <Input
+              size="small"
+              placeholder="Create new entity"
+              value={newEntityName}
+              onChange={(event) => setNewEntityName(event.target.value)}
+              onPressEnter={handleCreateEntity}
+            />
+            <Button
+              type="primary"
+              size="small"
+              icon={<PlusOutlined />}
+              onClick={handleCreateEntity}
+            >
+              Add
+            </Button>
+          </div>
+          <Typography.Text
+            type="secondary"
+            style={{ display: "block", padding: "0 12px 8px", fontSize: 12 }}
+          >
+            Entities are managed in the Entity CMS. New entities will appear in
+            the list above.
+          </Typography.Text>
+        </div>
+      )}
+      className={className}
+      filterOption={(input, option) =>
+        (option?.label as string)
+          ?.toLowerCase()
+          .includes((input || "").toLowerCase()) ?? false
+      }
+    />
+  );
+};
+
+export default EntityPicker;

--- a/src/components/common/IntentPicker.tsx
+++ b/src/components/common/IntentPicker.tsx
@@ -1,0 +1,278 @@
+import React, { useMemo, useState } from "react";
+import {
+  Select,
+  Typography,
+  Divider,
+  Space,
+  Button,
+  Modal,
+  Input,
+  Form,
+} from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import {
+  addIntent,
+  addIntentDetailed,
+} from "../../store/slices/intentsSlice";
+
+export interface IntentPickerProps {
+  value?: string;
+  onChange?: (next: string) => void;
+  placeholder?: string;
+  style?: React.CSSProperties;
+  bordered?: boolean;
+  allowCreate?: boolean;
+  allowClear?: boolean;
+  size?: "small" | "middle" | "large";
+  createMode?: "inline" | "modal";
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  searchValue?: string;
+  createLabelFormat?: (search: string) => string;
+}
+
+const normalizeUtterances = (value?: string) => {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+};
+
+export default function IntentPicker({
+  value,
+  onChange,
+  placeholder,
+  style,
+  allowCreate = true,
+  allowClear = false,
+  size = "middle",
+  createMode = "inline",
+  open,
+  onOpenChange,
+  searchValue,
+  createLabelFormat,
+  bordered = true,
+}: IntentPickerProps) {
+  const intents = useAppSelector((s) => s.intents?.list || []);
+  const dispatch = useAppDispatch();
+  const [search, setSearch] = useState("");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [form] = Form.useForm();
+
+  const options = useMemo(
+    () => intents.map((intent) => ({ label: intent, value: intent })),
+    [intents]
+  );
+  const effectiveSearch = (searchValue ?? search).trim();
+  const filteredOptions = useMemo(() => {
+    if (!effectiveSearch) return options;
+    const q = effectiveSearch.toLowerCase();
+    return options.filter((opt) =>
+      String(opt.label).toLowerCase().includes(q)
+    );
+  }, [options, effectiveSearch]);
+
+  const handleCreate = (name: string) => {
+    const next = (name || "").trim();
+    if (!next) return;
+    dispatch(addIntent(next));
+    onChange?.(next);
+  };
+
+  const openModal = () => {
+    setModalOpen(true);
+  };
+
+  const submitModal = async () => {
+    try {
+      const values = await form.validateFields();
+      const name = (values.name || "").trim();
+      if (!name) return;
+      const utterances = normalizeUtterances(values.utterances);
+      dispatch(
+        addIntentDetailed({
+          name,
+          description: values.description?.trim() || undefined,
+          utterances: utterances.length ? utterances : undefined,
+        })
+      );
+      onChange?.(name);
+      setModalOpen(false);
+    } catch (error) {
+      // ignore validation errors
+    }
+  };
+
+  return (
+    <>
+      <Select
+        size={size}
+        showSearch
+        allowClear={allowClear}
+        value={value && value.length > 0 ? value : undefined}
+        onChange={(next) => {
+          if (typeof next === "undefined" || next === null) {
+            onChange?.("");
+            return;
+          }
+          onChange?.(String(next));
+        }}
+        onSelect={(next) => onChange?.(String(next))}
+        variant={bordered ? "outlined" : "borderless"}
+        onSearch={(query) => setSearch(query)}
+        open={open}
+        onOpenChange={onOpenChange}
+        placeholder={placeholder}
+        options={filteredOptions}
+        filterOption={false}
+        popupMatchSelectWidth={false}
+        placement="bottomLeft"
+        getPopupContainer={(node) => {
+          let container = document.getElementById("intent-picker-portal");
+          if (!container) {
+            container = document.createElement("div");
+            container.id = "intent-picker-portal";
+            container.style.position = "absolute";
+            container.style.top = "0";
+            container.style.left = "0";
+            container.style.zIndex = "99999999";
+            (container as HTMLDivElement).dataset.insideMenu = "true";
+            document.body.appendChild(container);
+          }
+          (container as HTMLDivElement).dataset.insideMenu = "true";
+          return container;
+        }}
+        styles={{
+          popup: {
+            root: {
+              zIndex: 99999999,
+              position: "fixed",
+              minWidth: 180,
+              maxWidth: 260,
+            },
+          },
+        }}
+        style={style}
+        popupRender={(menu) => (
+          <div
+            onMouseDownCapture={(event) => {
+              const target = event.target as HTMLElement;
+              const option = (
+                target.closest(".ant-select-item-option") ||
+                target.closest('[role="option"]')
+              ) as HTMLElement | null;
+              if (option && onChange) {
+                const val =
+                  option.getAttribute("data-value") ||
+                  option.getAttribute("title") ||
+                  (option.textContent || "").trim();
+                if (val) {
+                  onChange(String(val));
+                  onOpenChange?.(false);
+                }
+              }
+            }}
+            onClickCapture={(event) => {
+              const target = event.target as HTMLElement;
+              const option = (
+                target.closest(".ant-select-item-option") ||
+                target.closest('[role="option"]')
+              ) as HTMLElement | null;
+              if (option && onChange) {
+                const val =
+                  option.getAttribute("data-value") ||
+                  option.getAttribute("title") ||
+                  (option.textContent || "").trim();
+                if (val) {
+                  onChange(String(val));
+                  onOpenChange?.(false);
+                }
+              }
+            }}
+          >
+            {menu}
+            {allowCreate && (
+              <>
+                <Divider style={{ margin: "4px 0" }} />
+                <Space
+                  style={{
+                    padding: 8,
+                    width: "100%",
+                    justifyContent: "flex-start",
+                  }}
+                >
+                  {createMode === "modal" ? (
+                    <Button
+                      type="link"
+                      icon={<PlusOutlined />}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={openModal}
+                    >
+                      Create intent…
+                    </Button>
+                  ) : (
+                    <Button
+                      type="link"
+                      icon={<PlusOutlined />}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => handleCreate(effectiveSearch)}
+                      disabled={!effectiveSearch}
+                    >
+                      {createLabelFormat
+                        ? createLabelFormat(effectiveSearch)
+                        : `Create "${effectiveSearch || ""}"`}
+                    </Button>
+                  )}
+                </Space>
+              </>
+            )}
+          </div>
+        )}
+      />
+
+      <Modal
+        title="Create Intent"
+        open={modalOpen}
+        onCancel={() => setModalOpen(false)}
+        onOk={submitModal}
+        okText="Create"
+        destroyOnClose
+        zIndex={100000}
+        afterOpenChange={(opened) => {
+          if (opened) {
+            form.resetFields();
+            form.setFieldsValue({ name: search.trim() });
+          }
+        }}
+      >
+        <Form form={form} layout="vertical" preserve={false}>
+          <Form.Item
+            name="name"
+            label="Name"
+            rules={[{ required: true, message: "Name is required" }]}
+          >
+            <Input placeholder="e.g. order_status" autoFocus />
+          </Form.Item>
+          <Form.Item name="description" label="Description">
+            <Input placeholder="Optional description" />
+          </Form.Item>
+          <Form.Item
+            name="utterances"
+            label={
+              <div>
+                <div>Sample utterances</div>
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  Separate with commas
+                </Typography.Text>
+              </div>
+            }
+          >
+            <Input placeholder="e.g. track my order, where is my package" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/voiceflow/Canvas.tsx
+++ b/src/components/voiceflow/Canvas.tsx
@@ -186,7 +186,6 @@ export default function Canvas() {
       const createChoice = (label: string) => ({
         id: `choice-${uniqueId()}`,
         label,
-        automaticallyReprompt: false,
       });
 
       const newNode = {

--- a/src/components/voiceflow/Canvas.tsx
+++ b/src/components/voiceflow/Canvas.tsx
@@ -183,6 +183,11 @@ export default function Canvas() {
         imageFileName: "",
         buttons: [createButton("Select")],
       });
+      const createChoice = (label: string) => ({
+        id: `choice-${uniqueId()}`,
+        label,
+        automaticallyReprompt: false,
+      });
 
       const newNode = {
         id: `${type}-${Date.now()}`,
@@ -193,7 +198,9 @@ export default function Canvas() {
           // Default data based on block type
           ...(type === "message" && { text: "Hello! How can I help you?" }),
           ...(type === "buttons" && { options: ["Option 1", "Option 2"] }),
-          ...(type === "choice" && { choices: ["Choice A", "Choice B"] }),
+          ...(type === "choice" && {
+            choices: [createChoice("Choice A"), createChoice("Choice B")],
+          }),
           ...(type === "capture" && { variable: "user_input" }),
           ...(type === "condition" && {
             condition: 'variable == "value"',

--- a/src/components/voiceflow/Canvas.tsx
+++ b/src/components/voiceflow/Canvas.tsx
@@ -200,7 +200,22 @@ export default function Canvas() {
           ...(type === "choice" && {
             choices: [createChoice("Choice A"), createChoice("Choice B")],
           }),
-          ...(type === "capture" && { variable: "user_input" }),
+          ...(type === "capture" && {
+            captureMode: "entities",
+            entities: [],
+            variable: "",
+            listenForOtherTriggers: false,
+            noReply: { enabled: false, timeout: 10, prompt: "" },
+            autoReprompt: {
+              enabled: false,
+              temperature: 0.7,
+              maxTokens: 256,
+              systemPrompt: "",
+            },
+            rules: [],
+            exitScenarios: [],
+            exitPathEnabled: false,
+          }),
           ...(type === "condition" && {
             condition: 'variable == "value"',
             elsePath: false,

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1501,7 +1501,6 @@
   }
 }
 
-
 .buttonsNodeEditor {
   display: flex;
   flex-direction: column;
@@ -1878,7 +1877,9 @@
   cursor: pointer;
   font: inherit;
   appearance: none;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 
   &:hover,
   &:focus-visible {
@@ -1933,6 +1934,38 @@
   border-radius: 12px;
   height: 36px;
   font-weight: 600;
+}
+
+.buttonsPathLabel {
+  margin-top: 12px;
+  width: 100%;
+  border: 1px solid #dbe4f0;
+  border-radius: 14px;
+  background: #f8fbff;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.buttonsPathLabelTitle {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
+  letter-spacing: 0.02em;
+}
+
+.buttonsPathLabelValue {
+  font-size: 13px;
+  font-weight: 500;
+  color: #0f172a;
+}
+
+.buttonsPathLabelNote {
+  font-size: 11px;
+  font-weight: 400;
+  color: #64748b;
+  font-style: italic;
 }
 
 .buttonsLinkPopover {
@@ -2213,14 +2246,16 @@
 .captureEntitiesList {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 20px;
+  padding: 16px 0;
 }
 
 .captureEntityRow {
   display: flex;
   gap: 8px;
-  align-items: flex-start;
-  padding: 12px;
+  align-items: center;
+  padding: 0 20px;
+  min-height: 48px;
   border: 1px solid #e2e8f0;
   border-radius: 8px;
   background: #f8fafc;
@@ -2272,7 +2307,6 @@
 }
 
 .captureToggleCard {
-  border: 1px solid #e2e8f0;
   border-radius: 8px;
   background: #ffffff;
   padding: 12px;
@@ -2353,4 +2387,294 @@
 .captureAutoRepromptFields > .captureFallbackFieldGroup {
   flex: 1;
   min-width: 140px;
+}
+
+// Entity Creation Modal Styles
+.entityPopoverContainer {
+  min-width: 260px;
+  padding: 0;
+}
+
+.entityPopoverSearchContainer {
+  padding: 12px 16px 8px 16px;
+}
+
+.entityPopoverSearchRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.entityPopoverSearchIcon {
+  color: #94a3b8;
+}
+
+.entityPopoverSearchInput {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 16px;
+  background: transparent;
+}
+
+.entityPopoverDivider {
+  border-top: 1px solid #eee;
+}
+
+.entityPopoverList {
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.entityPopoverItem {
+  padding: 12px 16px;
+  cursor: pointer;
+  font-size: 16px;
+
+  &:hover {
+    background-color: #f5f5f5;
+  }
+}
+
+.entityPopoverCreateAction {
+  padding: 12px 16px;
+  text-align: center;
+}
+
+.entityPopoverCreateButton {
+  color: #2563eb;
+  font-weight: 500;
+  cursor: pointer;
+  font-size: 16px;
+
+  &:hover {
+    color: #1d4ed8;
+  }
+}
+
+.entityValuesHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  width: 100%;
+}
+
+.entityValuesLabel {
+  color: rgba(0, 0, 0, 0.85);
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.entityValuesRequired {
+  color: #ff4d4f;
+}
+
+.entityValuesContainer {
+  width: 100%;
+}
+
+.entityValueRow {
+  width: 100%;
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  margin-bottom: 8px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.entityValueInput {
+  flex: 1;
+  width: 100%;
+}
+
+.entityValuesToggle {
+  text-align: center;
+  padding: 8px 0;
+  border-top: 1px solid #f0f0f0;
+  margin-top: 8px;
+}
+
+.entityValuesToggleButton {
+  padding: 0;
+  height: auto;
+}
+
+.entityValuesHelperText {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+// Entity popover styles
+.entityPopoverContainer {
+  min-width: 260px;
+  padding: 0;
+}
+
+.entityPopoverSearchContainer {
+  padding: 12px 16px 8px 16px;
+}
+
+.entityPopoverSearchRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.entityPopoverSearchIcon {
+  color: #94a3b8;
+}
+
+.entityPopoverSearchInput {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 16px;
+  background: transparent;
+}
+
+.entityPopoverDivider {
+  border-top: 1px solid #eee;
+}
+
+.entityPopoverList {
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.entityPopoverItem {
+  padding: 12px 16px;
+  cursor: pointer;
+  font-size: 16px;
+
+  &:hover {
+    background-color: #f8f9fa;
+  }
+}
+
+.entityPopoverCreateAction {
+  padding: 12px 16px;
+  text-align: center;
+}
+
+.entityPopoverCreateButton {
+  color: #2563eb;
+  font-weight: 500;
+  cursor: pointer;
+  font-size: 16px;
+
+  &:hover {
+    color: #1d4ed8;
+  }
+}
+
+// Entity modal styles
+.entityModalValuesHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  width: 100%;
+}
+
+.entityModalValuesLabel {
+  color: rgba(0, 0, 0, 0.85);
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.entityModalRequiredStar {
+  color: #ff4d4f;
+}
+
+.entityModalValuesContainer {
+  width: 100%;
+}
+
+.entityModalValueRow {
+  width: 100%;
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  margin-bottom: 8px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.entityModalValueInput {
+  flex: 1;
+  width: 100%;
+}
+
+.entityModalToggleContainer {
+  text-align: center;
+  padding: 8px 0;
+  border-top: 1px solid #f0f0f0;
+  margin-top: 8px;
+}
+
+.entityModalToggleButton {
+  padding: 0;
+  height: auto;
+}
+
+.entityModalHelperText {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+// Rules section clean styling
+.rulesContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ruleItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 0;
+}
+
+.ruleTextarea {
+  flex: 1;
+  border-radius: 6px !important;
+  border: 1px solid #e8e8e8 !important;
+  font-size: 14px !important;
+  line-height: 20px !important;
+  padding: 8px 12px !important;
+  resize: none !important;
+  background-color: #ffffff !important;
+}
+
+.ruleRemoveButton {
+  min-width: 32px !important;
+  height: 32px !important;
+  padding: 4px !important;
+  border: none !important;
+  border-radius: 4px !important;
+  color: #8c8c8c !important;
+  background-color: transparent !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  margin-top: 4px !important;
+
+  &:hover {
+    background-color: #f5f5f5 !important;
+    color: #000000 !important;
+  }
+}
+
+.rulesSectionDivider {
+  margin: 20px 0;
+  border-color: #f0f0f0;
 }

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -2328,3 +2328,29 @@
 .captureAddRowButton {
   align-self: flex-start;
 }
+
+.captureFallbackFieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.captureFallbackFieldGroup :global(.ant-input-number),
+.captureFallbackFieldGroup :global(.ant-input) {
+  width: 100%;
+}
+
+.captureFallbackTextarea {
+  width: 100%;
+}
+
+.captureAutoRepromptFields {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.captureAutoRepromptFields > .captureFallbackFieldGroup {
+  flex: 1;
+  min-width: 140px;
+}

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -2183,3 +2183,141 @@
   gap: 8px;
   margin-top: 8px;
 }
+
+// Capture Properties Styles
+.captureModeGroup {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.captureSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.captureEntitiesHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.captureEntitiesList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.captureEntityRow {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+.captureEntityColumn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.captureEntityActions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 32px;
+}
+
+.captureRemoveButton {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ef4444;
+  background: #fff5f5;
+
+  &:hover {
+    border-color: #fecaca;
+    background: #fee2e2;
+  }
+}
+
+.captureEntityMeta {
+  display: flex;
+  gap: 8px;
+}
+
+.captureEmptyState {
+  padding: 12px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  color: #64748b;
+  font-size: 13px;
+  text-align: center;
+}
+
+.captureToggleCard {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.captureToggleHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.captureToggleDescription {
+  font-size: 12px;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+.captureInlineInputs {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.captureList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.captureListItem {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 12px;
+  background: #f8fafc;
+  display: flex;
+  gap: 12px;
+}
+
+.captureListTextarea {
+  flex: 1;
+}
+
+.captureListActions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.captureAddRowButton {
+  align-self: flex-start;
+}

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1299,7 +1299,7 @@
 .choiceItem {
   border: 1px solid #e2e8f0;
   border-radius: 16px;
-  padding: 12px;
+  padding: 16px;
   background: #ffffff;
   display: flex;
   flex-direction: column;
@@ -1309,7 +1309,7 @@
 
 .choiceItemHeader {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 12px;
 }
 
@@ -1319,18 +1319,27 @@
 
 .choiceItemActions {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
   gap: 8px;
 }
 
 .choiceConfigureButton {
   padding: 0;
   height: auto;
+  font-weight: 500;
 }
 
 .choiceRemoveButton {
   color: #94a3b8;
+
+  &:global(.ant-btn-text) {
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+  }
 
   &:hover {
     color: #ef4444;
@@ -1341,6 +1350,8 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #f1f5f9;
 }
 
 .choiceSummaryRow {
@@ -1354,15 +1365,27 @@
   font-weight: 600;
   color: #64748b;
   text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .choiceSummaryValue {
   font-size: 13px;
-  color: #1f2937;
+  color: #0f172a;
+  font-weight: 500;
 }
 
 .choiceAddButton {
   align-self: flex-start;
+
+  &:global(.ant-btn) {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0 12px;
+    height: 36px;
+    border-radius: 12px;
+    border-style: dashed;
+  }
 }
 
 .choicePopoverOverlay {

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -2185,10 +2185,17 @@
 }
 
 // Capture Properties Styles
-.captureModeGroup {
-  display: flex;
-  gap: 8px;
-  align-items: center;
+.captureModeSelect {
+  max-width: 220px;
+}
+
+.captureModeSelect :global(.ant-select-selector) {
+  border-radius: 12px;
+  padding: 4px 12px;
+}
+
+.captureModeSelect :global(.ant-select-selection-item) {
+  font-weight: 500;
 }
 
 .captureSection {

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1300,22 +1300,16 @@
 
 .choiceListItem {
   display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  padding: 12px 16px;
-  background: #f8fafc;
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    background 0.2s ease;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
 }
 
 .choiceListItemActive {
-  border-color: #1677ff;
-  box-shadow: 0 0 0 2px rgba(22, 119, 255, 0.12);
-  background: #f0f6ff;
+  .choiceListTrigger {
+    background: #eef2ff;
+    border-color: rgba(79, 70, 229, 0.4);
+  }
 }
 
 .choiceListItemEmpty {
@@ -1329,56 +1323,50 @@
   font-size: 13px;
 }
 
-.choiceListContent {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  min-width: 0;
-}
-
-.choiceLabelInput {
-  flex: 1;
-
-  :global(.ant-input) {
-    border: none;
-    box-shadow: none !important;
-    background: transparent;
-    padding: 0;
-    height: auto;
-    font-size: 14px;
-    font-weight: 600;
-    color: #0f172a;
-  }
-
-  :global(.ant-input:focus),
-  :global(.ant-input-focused) {
-    box-shadow: none;
-    background: transparent;
-  }
-
-  :global(.ant-input::placeholder) {
-    color: #cbd5f5;
-  }
-}
-
 .choiceItemActions {
   display: flex;
   align-items: center;
   gap: 4px;
-  align-self: flex-start;
 }
 
-.choiceConfigureButton {
-  padding: 0;
-  height: auto;
-  font-weight: 500;
-  color: #475569;
+.choiceListTrigger {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease;
+}
 
-  &:hover {
-    color: #1f2937;
-    background: transparent;
-  }
+.choiceListTrigger:hover {
+  background: #f1f5f9;
+}
+
+.choiceListTrigger:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.choiceListTriggerText {
+  font-size: 14px;
+  font-weight: 600;
+  color: #0f172a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.choiceListTriggerPlaceholder {
+  color: #94a3b8;
+  font-weight: 500;
 }
 
 .choiceRemoveButton {
@@ -1397,22 +1385,6 @@
     color: #ef4444;
     background: transparent;
   }
-}
-
-.choiceSummary {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.choiceSummaryValue {
-  font-size: 12px;
-  color: #0f172a;
-  font-weight: 500;
-}
-
-.choiceSummaryPlaceholder {
-  color: #94a3b8;
 }
 
 .choiceDivider {

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1285,48 +1285,100 @@
   gap: 12px;
 }
 
+.choiceHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .choiceList {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
-.choiceEmpty {
+.choiceListItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 12px 16px;
+  background: #f8fafc;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease;
+}
+
+.choiceListItemActive {
+  border-color: #1677ff;
+  box-shadow: 0 0 0 2px rgba(22, 119, 255, 0.12);
+  background: #f0f6ff;
+}
+
+.choiceListItemEmpty {
+  justify-content: space-between;
+  align-items: center;
   color: #94a3b8;
+  font-style: italic;
+}
+
+.choiceEmptyLabel {
   font-size: 13px;
 }
 
-.choiceItem {
-  border: 1px solid #e2e8f0;
-  border-radius: 16px;
-  padding: 16px;
-  background: #ffffff;
+.choiceListContent {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
-}
-
-.choiceItemHeader {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+  gap: 8px;
+  min-width: 0;
 }
 
 .choiceLabelInput {
   flex: 1;
+
+  :global(.ant-input) {
+    border: none;
+    box-shadow: none !important;
+    background: transparent;
+    padding: 0;
+    height: auto;
+    font-size: 14px;
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  :global(.ant-input:focus),
+  :global(.ant-input-focused) {
+    box-shadow: none;
+    background: transparent;
+  }
+
+  :global(.ant-input::placeholder) {
+    color: #cbd5f5;
+  }
 }
 
 .choiceItemActions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
+  align-self: flex-start;
 }
 
 .choiceConfigureButton {
   padding: 0;
   height: auto;
   font-weight: 500;
+  color: #475569;
+
+  &:hover {
+    color: #1f2937;
+    background: transparent;
+  }
 }
 
 .choiceRemoveButton {
@@ -1343,48 +1395,47 @@
 
   &:hover {
     color: #ef4444;
+    background: transparent;
   }
 }
 
 .choiceSummary {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 12px;
-  padding-top: 12px;
-  border-top: 1px solid #f1f5f9;
 }
 
 .choiceSummaryRow {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: 4px;
 }
 
 .choiceSummaryLabel {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
-  color: #64748b;
+  color: #94a3b8;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
 .choiceSummaryValue {
-  font-size: 13px;
+  font-size: 12px;
   color: #0f172a;
   font-weight: 500;
 }
 
 .choiceAddButton {
-  align-self: flex-start;
+  color: #475569;
+  padding: 0;
+
+  &:hover {
+    color: #0f172a;
+    background: transparent;
+  }
 
   &:global(.ant-btn) {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 0 12px;
-    height: 36px;
-    border-radius: 12px;
-    border-style: dashed;
+    height: auto;
   }
 }
 

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1401,28 +1401,18 @@
 
 .choiceSummary {
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.choiceSummaryRow {
-  display: flex;
   align-items: center;
-  gap: 4px;
-}
-
-.choiceSummaryLabel {
-  font-size: 11px;
-  font-weight: 600;
-  color: #94a3b8;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  gap: 8px;
 }
 
 .choiceSummaryValue {
   font-size: 12px;
   color: #0f172a;
   font-weight: 500;
+}
+
+.choiceSummaryPlaceholder {
+  color: #94a3b8;
 }
 
 .choiceDivider {

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1425,6 +1425,10 @@
   font-weight: 500;
 }
 
+.choiceDivider {
+  margin: 4px 0 0;
+}
+
 .choiceAddButton {
   color: #475569;
   padding: 0;
@@ -1581,6 +1585,12 @@
 
 .buttonsNodeDivider {
   margin: 8px 0 0;
+}
+
+.fallbackSection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .buttonsFallbackList {

--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -1279,6 +1279,118 @@
   padding: 0;
 }
 
+.choiceProperties {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.choiceList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.choiceEmpty {
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.choiceItem {
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 12px;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.choiceItemHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.choiceLabelInput {
+  flex: 1;
+}
+
+.choiceItemActions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.choiceConfigureButton {
+  padding: 0;
+  height: auto;
+}
+
+.choiceRemoveButton {
+  color: #94a3b8;
+
+  &:hover {
+    color: #ef4444;
+  }
+}
+
+.choiceSummary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.choiceSummaryRow {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.choiceSummaryLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+}
+
+.choiceSummaryValue {
+  font-size: 13px;
+  color: #1f2937;
+}
+
+.choiceAddButton {
+  align-self: flex-start;
+}
+
+.choicePopoverOverlay {
+  max-width: 320px;
+}
+
+.choicePopover {
+  width: 260px;
+}
+
+.choicePopover :global(.ant-form-item) {
+  margin-bottom: 12px;
+}
+
+.choicePopoverTitle {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #1f2937;
+}
+
+.choicePopoverFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
 .buttonsNodeProperties {
   display: flex;
   flex-direction: column;

--- a/src/components/voiceflow/PropertiesPanel.tsx
+++ b/src/components/voiceflow/PropertiesPanel.tsx
@@ -41,7 +41,6 @@ import {
   Dropdown,
   Collapse,
   Switch,
-  Radio,
   Popover,
   Divider,
   Space,
@@ -2871,17 +2870,16 @@ export default function PropertiesPanel({
 
     return (
       <Form layout="vertical">
-        <Form.Item label="Capture mode">
-          <Radio.Group
+        <Form.Item label="Capture">
+          <Select
             value={captureMode}
-            onChange={(event) =>
-              commitCaptureMode(event.target.value as CaptureMode)
-            }
-            className={styles.captureModeGroup}
-          >
-            <Radio.Button value="entities">Entities</Radio.Button>
-            <Radio.Button value="reply">Entire User Reply</Radio.Button>
-          </Radio.Group>
+            onChange={(value) => commitCaptureMode(value as CaptureMode)}
+            options={[
+              { label: "Entities", value: "entities" },
+              { label: "Entire user reply", value: "reply" },
+            ]}
+            className={styles.captureModeSelect}
+          />
         </Form.Item>
 
         <Form.Item label="Prompt">

--- a/src/components/voiceflow/PropertiesPanel.tsx
+++ b/src/components/voiceflow/PropertiesPanel.tsx
@@ -3619,14 +3619,24 @@ export default function PropertiesPanel({
 
     return (
       <div className={styles.choiceProperties}>
-        <Typography.Text className={styles.sectionHeading}>
-          Choices
-        </Typography.Text>
+        <div className={styles.choiceHeaderRow}>
+          <Typography.Text className={styles.sectionHeading}>
+            Triggers
+          </Typography.Text>
+          <Button
+            icon={<PlusOutlined />}
+            type="text"
+            onClick={addChoice}
+            className={styles.choiceAddButton}
+          />
+        </div>
         <div className={styles.choiceList}>
           {choicesState.length === 0 ? (
-            <Typography.Text type="secondary" className={styles.choiceEmpty}>
-              No choices yet. Add one to branch your flow.
-            </Typography.Text>
+            <div
+              className={`${styles.choiceListItem} ${styles.choiceListItemEmpty}`}
+            >
+              <span className={styles.choiceEmptyLabel}>None</span>
+            </div>
           ) : (
             choicesState.map((choice) => {
               const isActive = activeChoiceId === choice.id;
@@ -3641,8 +3651,13 @@ export default function PropertiesPanel({
                 ? "On"
                 : "Off";
               return (
-                <div key={choice.id} className={styles.choiceItem}>
-                  <div className={styles.choiceItemHeader}>
+                <div
+                  key={choice.id}
+                  className={`${styles.choiceListItem} ${
+                    isActive ? styles.choiceListItemActive : ""
+                  }`}
+                >
+                  <div className={styles.choiceListContent}>
                     <ValueInput
                       value={choice.label}
                       onChange={(value) =>
@@ -3654,146 +3669,134 @@ export default function PropertiesPanel({
                         setActiveChoiceId(null);
                       }}
                       placeholder="Enter choice label or {variable}"
-                      size="large"
+                      size="middle"
                       className={styles.choiceLabelInput}
                     />
-                    <div className={styles.choiceItemActions}>
-                      <Popover
-                        trigger="click"
-                        open={isActive}
-                        onOpenChange={(open) => {
-                          if (open) {
-                            setActiveChoiceId(choice.id);
-                            setDraftChoice({ ...choice });
-                          } else {
-                            closePopover();
-                          }
-                        }}
-                        placement="right"
-                        overlayClassName={styles.choicePopoverOverlay}
-                        content={
-                          <div className={styles.choicePopover}>
-                            <Typography.Text
-                              className={styles.choicePopoverTitle}
-                            >
-                              Choice settings
-                            </Typography.Text>
-                            <Form layout="vertical">
-                              <Form.Item label="Intent">
-                                <IntentPicker
-                                  value={effectiveChoice.intent || ""}
-                                  onChange={(nextIntent) => {
-                                    setDraftChoice((current) => {
-                                      if (!current || current.id !== choice.id)
-                                        return current;
-                                      return {
-                                        ...current,
-                                        intent: nextIntent,
-                                      };
-                                    });
-                                  }}
-                                  placeholder="Select or create intent"
-                                  allowCreate
-                                  allowClear
-                                  createMode="modal"
-                                  size="middle"
-                                />
-                              </Form.Item>
-                              <Form.Item label="Button label">
-                                <Input
-                                  value={effectiveChoice.buttonLabel || ""}
-                                  onChange={(event) => {
-                                    const nextValue = event.target.value;
-                                    setDraftChoice((current) => {
-                                      if (!current || current.id !== choice.id)
-                                        return current;
-                                      return {
-                                        ...current,
-                                        buttonLabel: nextValue,
-                                      };
-                                    });
-                                  }}
-                                  placeholder="Optional button label"
-                                />
-                              </Form.Item>
-                              <Form.Item label="Automatically reprompt">
-                                <Switch
-                                  checked={
-                                    !!effectiveChoice.automaticallyReprompt
-                                  }
-                                  onChange={(checked) => {
-                                    setDraftChoice((current) => {
-                                      if (!current || current.id !== choice.id)
-                                        return current;
-                                      return {
-                                        ...current,
-                                        automaticallyReprompt: checked,
-                                      };
-                                    });
-                                  }}
-                                />
-                              </Form.Item>
-                            </Form>
-                            <div className={styles.choicePopoverFooter}>
-                              <Button onClick={closePopover}>Cancel</Button>
-                              <Button type="primary" onClick={saveDraftChoice}>
-                                Save
-                              </Button>
-                            </div>
-                          </div>
-                        }
-                      >
-                        <Button
-                          type="link"
-                          size="small"
-                          className={styles.choiceConfigureButton}
-                        >
-                          Configure
-                        </Button>
-                      </Popover>
-                      <Button
-                        type="text"
-                        icon={<MinusOutlined />}
-                        onClick={() => removeChoice(choice.id)}
-                        className={styles.choiceRemoveButton}
-                      />
+                    <div className={styles.choiceSummary}>
+                      <div className={styles.choiceSummaryRow}>
+                        <span className={styles.choiceSummaryLabel}>Intent</span>
+                        <span className={styles.choiceSummaryValue}>
+                          {summaryIntent}
+                        </span>
+                      </div>
+                      <div className={styles.choiceSummaryRow}>
+                        <span className={styles.choiceSummaryLabel}>Button</span>
+                        <span className={styles.choiceSummaryValue}>
+                          {summaryButton}
+                        </span>
+                      </div>
+                      <div className={styles.choiceSummaryRow}>
+                        <span className={styles.choiceSummaryLabel}>
+                          Auto reprompt
+                        </span>
+                        <span className={styles.choiceSummaryValue}>
+                          {summaryReprompt}
+                        </span>
+                      </div>
                     </div>
                   </div>
-                  <div className={styles.choiceSummary}>
-                    <div className={styles.choiceSummaryRow}>
-                      <span className={styles.choiceSummaryLabel}>Intent</span>
-                      <span className={styles.choiceSummaryValue}>
-                        {summaryIntent}
-                      </span>
-                    </div>
-                    <div className={styles.choiceSummaryRow}>
-                      <span className={styles.choiceSummaryLabel}>Button</span>
-                      <span className={styles.choiceSummaryValue}>
-                        {summaryButton}
-                      </span>
-                    </div>
-                    <div className={styles.choiceSummaryRow}>
-                      <span className={styles.choiceSummaryLabel}>
-                        Auto reprompt
-                      </span>
-                      <span className={styles.choiceSummaryValue}>
-                        {summaryReprompt}
-                      </span>
-                    </div>
+                  <div className={styles.choiceItemActions}>
+                    <Popover
+                      trigger="click"
+                      open={isActive}
+                      onOpenChange={(open) => {
+                        if (open) {
+                          setActiveChoiceId(choice.id);
+                          setDraftChoice({ ...choice });
+                        } else {
+                          closePopover();
+                        }
+                      }}
+                      placement="right"
+                      overlayClassName={styles.choicePopoverOverlay}
+                      content={
+                        <div className={styles.choicePopover}>
+                          <Typography.Text className={styles.choicePopoverTitle}>
+                            Choice settings
+                          </Typography.Text>
+                          <Form layout="vertical">
+                            <Form.Item label="Intent">
+                              <IntentPicker
+                                value={effectiveChoice.intent || ""}
+                                onChange={(nextIntent) => {
+                                  setDraftChoice((current) => {
+                                    if (!current || current.id !== choice.id)
+                                      return current;
+                                    return {
+                                      ...current,
+                                      intent: nextIntent,
+                                    };
+                                  });
+                                }}
+                                placeholder="Select or create intent"
+                                allowCreate
+                                allowClear
+                                createMode="modal"
+                                size="middle"
+                              />
+                            </Form.Item>
+                            <Form.Item label="Button label">
+                              <Input
+                                value={effectiveChoice.buttonLabel || ""}
+                                onChange={(event) => {
+                                  const nextValue = event.target.value;
+                                  setDraftChoice((current) => {
+                                    if (!current || current.id !== choice.id)
+                                      return current;
+                                    return {
+                                      ...current,
+                                      buttonLabel: nextValue,
+                                    };
+                                  });
+                                }}
+                                placeholder="Optional button label"
+                              />
+                            </Form.Item>
+                            <Form.Item label="Automatically reprompt">
+                              <Switch
+                                checked={!!effectiveChoice.automaticallyReprompt}
+                                onChange={(checked) => {
+                                  setDraftChoice((current) => {
+                                    if (!current || current.id !== choice.id)
+                                      return current;
+                                    return {
+                                      ...current,
+                                      automaticallyReprompt: checked,
+                                    };
+                                  });
+                                }}
+                              />
+                            </Form.Item>
+                          </Form>
+                          <div className={styles.choicePopoverFooter}>
+                            <Button onClick={closePopover}>Cancel</Button>
+                            <Button type="primary" onClick={saveDraftChoice}>
+                              Save
+                            </Button>
+                          </div>
+                        </div>
+                      }
+                    >
+                      <Button
+                        type="link"
+                        size="small"
+                        className={styles.choiceConfigureButton}
+                      >
+                        Configure
+                      </Button>
+                    </Popover>
+                    <Button
+                      type="text"
+                      icon={<MinusOutlined />}
+                      onClick={() => removeChoice(choice.id)}
+                      className={styles.choiceRemoveButton}
+                    />
                   </div>
                 </div>
               );
             })
           )}
         </div>
-        <Button
-          type="dashed"
-          icon={<PlusOutlined />}
-          onClick={addChoice}
-          className={styles.choiceAddButton}
-        >
-          Add choice
-        </Button>
       </div>
     );
   };

--- a/src/components/voiceflow/PropertiesPanel.tsx
+++ b/src/components/voiceflow/PropertiesPanel.tsx
@@ -3632,6 +3632,14 @@ export default function PropertiesPanel({
               const isActive = activeChoiceId === choice.id;
               const effectiveChoice =
                 isActive && draftChoice ? draftChoice : choice;
+              const summaryIntent =
+                (effectiveChoice.intent || "").trim() || "None";
+              const summaryButton =
+                (effectiveChoice.buttonLabel || "").trim() ||
+                "Not configured";
+              const summaryReprompt = effectiveChoice.automaticallyReprompt
+                ? "On"
+                : "Off";
               return (
                 <div key={choice.id} className={styles.choiceItem}>
                   <div className={styles.choiceItemHeader}>
@@ -3755,13 +3763,13 @@ export default function PropertiesPanel({
                     <div className={styles.choiceSummaryRow}>
                       <span className={styles.choiceSummaryLabel}>Intent</span>
                       <span className={styles.choiceSummaryValue}>
-                        {choice.intent || "None"}
+                        {summaryIntent}
                       </span>
                     </div>
                     <div className={styles.choiceSummaryRow}>
                       <span className={styles.choiceSummaryLabel}>Button</span>
                       <span className={styles.choiceSummaryValue}>
-                        {choice.buttonLabel || "Not configured"}
+                        {summaryButton}
                       </span>
                     </div>
                     <div className={styles.choiceSummaryRow}>
@@ -3769,7 +3777,7 @@ export default function PropertiesPanel({
                         Auto reprompt
                       </span>
                       <span className={styles.choiceSummaryValue}>
-                        {choice.automaticallyReprompt ? "On" : "Off"}
+                        {summaryReprompt}
                       </span>
                     </div>
                   </div>

--- a/src/components/voiceflow/PropertiesPanel.tsx
+++ b/src/components/voiceflow/PropertiesPanel.tsx
@@ -168,12 +168,18 @@ const normalizeChoiceOptions = (choices: any[]): ChoiceOption[] => {
     const rawLabel = typeof ensured.label === "string" ? ensured.label : "";
     const trimmedLabel = rawLabel.trim();
     const rawIntent = typeof ensured.intent === "string" ? ensured.intent : "";
+    const trimmedIntent = rawIntent.trim();
     const rawButtonLabel =
       typeof ensured.buttonLabel === "string" ? ensured.buttonLabel : "";
     return {
       id: ensured.id,
-      label: trimmedLabel.length > 0 ? trimmedLabel : "",
-      intent: rawIntent.trim() || undefined,
+      label:
+        trimmedLabel.length > 0
+          ? trimmedLabel
+          : trimmedIntent.length > 0
+          ? trimmedIntent
+          : "",
+      intent: trimmedIntent || undefined,
       buttonLabel: rawButtonLabel.trim() || undefined,
     };
   });
@@ -4173,13 +4179,12 @@ export default function PropertiesPanel({
 
     const saveDraftChoice = () => {
       if (!draftChoice) return;
-      const trimmedLabel = (draftChoice.label || "").trim();
       const trimmedIntent = (draftChoice.intent || "").trim();
       const trimmedButton = (draftChoice.buttonLabel || "").trim();
       updateChoice(
         draftChoice.id,
         {
-          label: trimmedLabel,
+          label: trimmedIntent.length > 0 ? trimmedIntent : "",
           intent: trimmedIntent || undefined,
           buttonLabel: trimmedButton.length > 0 ? trimmedButton : undefined,
         },
@@ -4216,13 +4221,13 @@ export default function PropertiesPanel({
               const summaryIntent = (effectiveChoice.intent || "").trim();
               const summaryLabel = (effectiveChoice.label || "").trim();
               const summaryDisplay =
-                summaryLabel.length > 0
-                  ? summaryLabel
-                  : summaryIntent.length > 0
+                summaryIntent.length > 0
                   ? summaryIntent
-                  : "Intent";
+                  : summaryLabel.length > 0
+                  ? summaryLabel
+                  : "Select intent";
               const isPlaceholder =
-                summaryLabel.length === 0 && summaryIntent.length === 0;
+                summaryIntent.length === 0 && summaryLabel.length === 0;
               return (
                 <div
                   key={choice.id}
@@ -4249,23 +4254,6 @@ export default function PropertiesPanel({
                           Choice settings
                         </Typography.Text>
                         <Form layout="vertical">
-                          <Form.Item label="Label">
-                            <Input
-                              value={effectiveChoice.label || ""}
-                              onChange={(event) => {
-                                const nextValue = event.target.value;
-                                setDraftChoice((current) => {
-                                  if (!current || current.id !== choice.id)
-                                    return current;
-                                  return {
-                                    ...current,
-                                    label: nextValue,
-                                  };
-                                });
-                              }}
-                              placeholder="Optional label"
-                            />
-                          </Form.Item>
                           <Form.Item label="Intent">
                             <IntentPicker
                               value={effectiveChoice.intent || ""}
@@ -4276,6 +4264,10 @@ export default function PropertiesPanel({
                                   return {
                                     ...current,
                                     intent: nextIntent,
+                                    label:
+                                      typeof nextIntent === "string"
+                                        ? nextIntent.trim()
+                                        : "",
                                   };
                                 });
                               }}

--- a/src/components/voiceflow/Sidebar.tsx
+++ b/src/components/voiceflow/Sidebar.tsx
@@ -300,7 +300,22 @@ export default function Sidebar() {
         ...(blockType === "choice" && {
           choices: [createChoice("Choice A"), createChoice("Choice B")],
         }),
-        ...(blockType === "capture" && { variable: "user_input" }),
+        ...(blockType === "capture" && {
+          captureMode: "entities",
+          entities: [],
+          variable: "",
+          listenForOtherTriggers: false,
+          noReply: { enabled: false, timeout: 10, prompt: "" },
+          autoReprompt: {
+            enabled: false,
+            temperature: 0.7,
+            maxTokens: 256,
+            systemPrompt: "",
+          },
+          rules: [],
+          exitScenarios: [],
+          exitPathEnabled: false,
+        }),
         ...(blockType === "condition" && {
           condition: 'variable == "value"',
           paths: [],

--- a/src/components/voiceflow/Sidebar.tsx
+++ b/src/components/voiceflow/Sidebar.tsx
@@ -287,7 +287,6 @@ export default function Sidebar() {
     const createChoice = (label: string) => ({
       id: `choice-${uniqueId()}`,
       label,
-      automaticallyReprompt: false,
     });
 
     const newNode = {

--- a/src/components/voiceflow/Sidebar.tsx
+++ b/src/components/voiceflow/Sidebar.tsx
@@ -284,6 +284,11 @@ export default function Sidebar() {
       imageFileName: "",
       buttons: [createButton("Select")],
     });
+    const createChoice = (label: string) => ({
+      id: `choice-${uniqueId()}`,
+      label,
+      automaticallyReprompt: false,
+    });
 
     const newNode = {
       id: `${blockType}-${Date.now()}`,
@@ -293,7 +298,9 @@ export default function Sidebar() {
         label: blockName,
         ...(blockType === "message" && { text: "" }),
         ...(blockType === "buttons" && { options: ["Option 1", "Option 2"] }),
-        ...(blockType === "choice" && { choices: ["Choice A", "Choice B"] }),
+        ...(blockType === "choice" && {
+          choices: [createChoice("Choice A"), createChoice("Choice B")],
+        }),
         ...(blockType === "capture" && { variable: "user_input" }),
         ...(blockType === "condition" && {
           condition: 'variable == "value"',

--- a/src/components/voiceflow/nodes/ButtonsNode.module.scss
+++ b/src/components/voiceflow/nodes/ButtonsNode.module.scss
@@ -64,7 +64,7 @@
 .node__buttonHandle {
   position: absolute;
   top: 50%;
-  right: -7px;
+  right: -12px;
   transform: translateY(-50%);
 }
 

--- a/src/components/voiceflow/nodes/ButtonsNode.module.scss
+++ b/src/components/voiceflow/nodes/ButtonsNode.module.scss
@@ -64,7 +64,7 @@
 .node__buttonHandle {
   position: absolute;
   top: 50%;
-  right: -12px;
+  right: -7px;
   transform: translateY(-50%);
 }
 

--- a/src/components/voiceflow/nodes/CaptureNode.module.scss
+++ b/src/components/voiceflow/nodes/CaptureNode.module.scss
@@ -63,6 +63,83 @@
   margin-bottom: 4px;
 }
 
+.entityList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.entityRow {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+  padding: 6px 8px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #f8fafc;
+}
+
+.entityName {
+  font-weight: 500;
+  color: #1f2937;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.entityVariable {
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 12px;
+  color: #475569;
+}
+
+.entityRequired,
+.entityOptional {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+}
+
+.entityRequired {
+  color: #b91c1c;
+  background: #fee2e2;
+  border-color: #fecaca;
+}
+
+.entityOptional {
+  color: #2563eb;
+  background: #dbeafe;
+  border-color: #bfdbfe;
+}
+
+.entityEmpty {
+  font-size: 12px;
+  color: #64748b;
+  text-align: center;
+  padding: 8px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 6px;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.metaBadge {
+  font-size: 11px;
+  background: #e0f2fe;
+  color: #0369a1;
+  border-radius: 9999px;
+  padding: 2px 8px;
+}
+
 .handle {
   width: 10px;
   height: 10px;

--- a/src/components/voiceflow/nodes/CaptureNode.module.scss
+++ b/src/components/voiceflow/nodes/CaptureNode.module.scss
@@ -4,7 +4,10 @@
   border-radius: 8px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   width: 240px;
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
   font-size: 14px;
   color: #1f2328;
 
@@ -71,14 +74,31 @@
 }
 
 .entityRow {
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  gap: 8px;
+  display: flex;
   align-items: center;
   padding: 6px 8px;
   border: 1px solid #e2e8f0;
   border-radius: 6px;
   background: #f8fafc;
+  margin-bottom: 4px;
+  position: relative;
+}
+
+.entityContent {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+  flex: 1;
+}
+
+.entityHandle {
+  margin-left: 8px;
+  position: absolute;
+  right: -17px; /* Position outside the node border */
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
 }
 
 .entityName {
@@ -91,7 +111,7 @@
 }
 
 .entityVariable {
-  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
   font-size: 12px;
   color: #475569;
 }
@@ -125,6 +145,48 @@
   border-radius: 6px;
 }
 
+.exitRow {
+  display: flex;
+  align-items: center;
+  padding: 6px 8px;
+  border: 1px solid #ff6b35;
+  border-radius: 6px;
+  background: #fff5f2;
+  margin-top: 8px;
+  position: relative;
+}
+
+.exitContent {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.exitName {
+  font-weight: 500;
+  color: #ff6b35;
+  font-size: 13px;
+  cursor: pointer;
+  
+  &:hover {
+    color: #ff5722;
+  }
+}
+
+.exitDescription {
+  font-size: 11px;
+  color: #cc5a2a;
+}
+
+.exitHandle {
+  margin-left: 8px;
+  position: absolute;
+  right: -17px; /* Position outside the node border */
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+}
+
 .metaRow {
   display: flex;
   flex-wrap: wrap;
@@ -138,6 +200,16 @@
   color: #0369a1;
   border-radius: 9999px;
   padding: 2px 8px;
+}
+
+.clickableBadge {
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #b8e6ff;
+    transform: translateY(-1px);
+  }
 }
 
 .handle {
@@ -159,5 +231,43 @@
     left: 50%;
     transform: translateX(-50%);
     background: #52c41a;
+  }
+
+  &--right {
+    right: -5px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: #52c41a; // Green for entity handles
+  }
+
+  &--entity {
+    position: static;
+    right: auto;
+    top: auto;
+    transform: none;
+    background: #52c41a; // Green for entity handles
+    width: 10px;
+    height: 10px;
+    border-radius: 5px;
+    border: 2px solid white;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+  }
+
+  &--exit {
+    position: static;
+    right: auto;
+    top: auto;
+    transform: none;
+    background: #ff6b35; // Orange for exit handle
+    width: 10px;
+    height: 10px;
+    border-radius: 5px;
+    border: 2px solid white;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+  }
+
+  // Orange color for exit path handle
+  &[data-handleid="exit-path"] {
+    background: #ff6b35 !important;
   }
 }

--- a/src/components/voiceflow/nodes/CaptureNode.tsx
+++ b/src/components/voiceflow/nodes/CaptureNode.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { Handle, Position, NodeProps } from 'reactflow';
 import { EditOutlined } from '@ant-design/icons';
 import { useAppDispatch } from '../../../store/hooks';
@@ -6,18 +6,86 @@ import { updateNode } from '../../../store/slices/workflowSlice';
 import { NodeHeader } from './shared/NodeHeader';
 import styles from './CaptureNode.module.scss';
 
+type CaptureMode = 'entities' | 'reply';
+
+interface CaptureEntitySummary {
+  id: string;
+  entity: string;
+  variable?: string;
+  required: boolean;
+}
+
+interface CaptureNoReplySummary {
+  enabled: boolean;
+  timeout?: number;
+  prompt?: string;
+}
+
+interface CaptureAutoRepromptSummary {
+  enabled?: boolean;
+  temperature?: number;
+  maxTokens?: number;
+  systemPrompt?: string;
+}
+
 interface CaptureNodeData {
   label: string;
   variable?: string;
   prompt?: string;
   validation?: string;
+  captureMode?: CaptureMode;
+  entities?: CaptureEntitySummary[];
+  listenForOtherTriggers?: boolean;
+  noReply?: CaptureNoReplySummary;
+  autoReprompt?: CaptureAutoRepromptSummary;
+  exitPathEnabled?: boolean;
   __editingLabel?: boolean;
 }
+
+const normalizeCaptureEntities = (input: any): CaptureEntitySummary[] => {
+  if (!Array.isArray(input)) return [];
+  return input.map((entry, index) => {
+    const fallbackId = `capture-entity-${index}`;
+    if (!entry || typeof entry !== 'object') {
+      return {
+        id: fallbackId,
+        entity: '',
+        variable: undefined,
+        required: true,
+      };
+    }
+
+    const rawEntity =
+      typeof entry.entity === 'string'
+        ? entry.entity
+        : typeof entry.name === 'string'
+        ? entry.name
+        : '';
+    const rawVariable =
+      typeof entry.variable === 'string'
+        ? entry.variable
+        : typeof entry.slot === 'string'
+        ? entry.slot
+        : '';
+
+    return {
+      id: typeof entry.id === 'string' ? entry.id : fallbackId,
+      entity: rawEntity.trim(),
+      variable: rawVariable.trim() || undefined,
+      required: entry.required === false ? false : true,
+    };
+  });
+};
 
 export default function CaptureNode({ data, selected, id }: NodeProps<CaptureNodeData>) {
   const dispatch = useAppDispatch();
   const [editing, setEditing] = useState(!!data.__editingLabel);
   const [label, setLabel] = useState(data.label || 'Capture');
+  const captureMode: CaptureMode =
+    data.captureMode === 'reply' ? 'reply' : 'entities';
+  const entities = useMemo(() => normalizeCaptureEntities(data.entities), [
+    data.entities,
+  ]);
 
   useEffect(() => {
     setEditing(!!data.__editingLabel);
@@ -67,15 +135,67 @@ export default function CaptureNode({ data, selected, id }: NodeProps<CaptureNod
             {data.prompt}
           </div>
         )}
-        <div className={styles.row}>
-          <div className={styles.kvLabel}>Variable:</div>
-          <div className={styles.badgeMono}>
-            {data.variable || 'user_input'}
+        {captureMode === 'entities' ? (
+          <div className={styles.entityList}>
+            {entities.length === 0 ? (
+              <div className={styles.entityEmpty}>Configure entities to capture</div>
+            ) : (
+              entities.map((entity) => (
+                <div key={entity.id} className={styles.entityRow}>
+                  <div className={styles.entityName}>
+                    {entity.entity || 'Select entity'}
+                  </div>
+                  <div className={styles.entityVariable}>
+                    {entity.variable ? `{${entity.variable}}` : 'No variable'}
+                  </div>
+                  <div
+                    className={
+                      entity.required
+                        ? styles.entityRequired
+                        : styles.entityOptional
+                    }
+                  >
+                    {entity.required ? 'Required' : 'Optional'}
+                  </div>
+                </div>
+              ))
+            )}
           </div>
-        </div>
+        ) : (
+          <div className={styles.row}>
+            <div className={styles.kvLabel}>Variable:</div>
+            <div className={styles.badgeMono}>
+              {data.variable || 'user_input'}
+            </div>
+          </div>
+        )}
         {data.validation && (
           <div className={styles.validation}>
             Validation: {data.validation}
+          </div>
+        )}
+        {(data.listenForOtherTriggers ||
+          data.noReply?.enabled ||
+          (captureMode === 'entities' && data.autoReprompt?.enabled) ||
+          (captureMode === 'entities' && data.exitPathEnabled)) && (
+          <div className={styles.metaRow}>
+            {data.listenForOtherTriggers && (
+              <span className={styles.metaBadge}>
+                Listening for other triggers
+              </span>
+            )}
+            {data.noReply?.enabled && (
+              <span className={styles.metaBadge}>
+                No reply{' '}
+                {data.noReply?.timeout ? `(${data.noReply.timeout}s)` : ''}
+              </span>
+            )}
+            {captureMode === 'entities' && data.autoReprompt?.enabled && (
+              <span className={styles.metaBadge}>Auto reprompt</span>
+            )}
+            {captureMode === 'entities' && data.exitPathEnabled && (
+              <span className={styles.metaBadge}>Exit path</span>
+            )}
           </div>
         )}
       </div>

--- a/src/components/voiceflow/nodes/CaptureNode.tsx
+++ b/src/components/voiceflow/nodes/CaptureNode.tsx
@@ -1,12 +1,13 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
-import { Handle, Position, NodeProps } from 'reactflow';
-import { EditOutlined } from '@ant-design/icons';
-import { useAppDispatch } from '../../../store/hooks';
-import { updateNode } from '../../../store/slices/workflowSlice';
-import { NodeHeader } from './shared/NodeHeader';
-import styles from './CaptureNode.module.scss';
+import React, { useState, useCallback, useEffect, useMemo } from "react";
+import { Handle, Position, NodeProps } from "reactflow";
+import { EditOutlined, EditFilled } from "@ant-design/icons";
+import { Input, Popover } from "antd";
+import { useAppDispatch } from "../../../store/hooks";
+import { updateNode } from "../../../store/slices/workflowSlice";
+import { NodeHeader } from "./shared/NodeHeader";
+import styles from "./CaptureNode.module.scss";
 
-type CaptureMode = 'entities' | 'reply';
+type CaptureMode = "entities" | "reply";
 
 interface CaptureEntitySummary {
   id: string;
@@ -39,6 +40,7 @@ interface CaptureNodeData {
   noReply?: CaptureNoReplySummary;
   autoReprompt?: CaptureAutoRepromptSummary;
   exitPathEnabled?: boolean;
+  exitPathLabel?: string;
   __editingLabel?: boolean;
 }
 
@@ -46,30 +48,30 @@ const normalizeCaptureEntities = (input: any): CaptureEntitySummary[] => {
   if (!Array.isArray(input)) return [];
   return input.map((entry, index) => {
     const fallbackId = `capture-entity-${index}`;
-    if (!entry || typeof entry !== 'object') {
+    if (!entry || typeof entry !== "object") {
       return {
         id: fallbackId,
-        entity: '',
+        entity: "",
         variable: undefined,
         required: true,
       };
     }
 
     const rawEntity =
-      typeof entry.entity === 'string'
+      typeof entry.entity === "string"
         ? entry.entity
-        : typeof entry.name === 'string'
+        : typeof entry.name === "string"
         ? entry.name
-        : '';
+        : "";
     const rawVariable =
-      typeof entry.variable === 'string'
+      typeof entry.variable === "string"
         ? entry.variable
-        : typeof entry.slot === 'string'
+        : typeof entry.slot === "string"
         ? entry.slot
-        : '';
+        : "";
 
     return {
-      id: typeof entry.id === 'string' ? entry.id : fallbackId,
+      id: typeof entry.id === "string" ? entry.id : fallbackId,
       entity: rawEntity.trim(),
       variable: rawVariable.trim() || undefined,
       required: entry.required === false ? false : true,
@@ -77,107 +79,143 @@ const normalizeCaptureEntities = (input: any): CaptureEntitySummary[] => {
   });
 };
 
-export default function CaptureNode({ data, selected, id }: NodeProps<CaptureNodeData>) {
+export default function CaptureNode({
+  data,
+  selected,
+  id,
+}: NodeProps<CaptureNodeData>) {
   const dispatch = useAppDispatch();
   const [editing, setEditing] = useState(!!data.__editingLabel);
-  const [label, setLabel] = useState(data.label || 'Capture');
+  const [label, setLabel] = useState(data.label || "Capture");
+
   const captureMode: CaptureMode =
-    data.captureMode === 'reply' ? 'reply' : 'entities';
-  const entities = useMemo(() => normalizeCaptureEntities(data.entities), [
-    data.entities,
-  ]);
+    data.captureMode === "reply" ? "reply" : "entities";
+  const entities = useMemo(
+    () => normalizeCaptureEntities(data.entities),
+    [data.entities]
+  );
 
   useEffect(() => {
     setEditing(!!data.__editingLabel);
   }, [data.__editingLabel]);
 
-  const commitLabel = useCallback((next: string) => {
-    const trimmed = (next || '').trim();
-    dispatch(updateNode({ 
-      id, 
-      data: { 
-        ...data,
-        label: trimmed || data.label,
-        __editingLabel: false 
-      } 
-    }));
-    setEditing(false);
-  }, [dispatch, id, data]);
+  const commitLabel = useCallback(
+    (next: string) => {
+      const trimmed = (next || "").trim();
+      dispatch(
+        updateNode({
+          id,
+          data: {
+            ...data,
+            label: trimmed || data.label,
+            __editingLabel: false,
+          },
+        })
+      );
+      setEditing(false);
+    },
+    [dispatch, id, data]
+  );
 
   const beginEdit = useCallback(() => {
     setEditing(true);
-    setLabel(data.label || 'Capture');
+    setLabel(data.label || "Capture");
   }, [data.label]);
 
   return (
-    <div className={`${styles.node} ${selected ? styles.selected : ''}`}>
+    <div className={`${styles.node} ${selected ? styles.selected : ""}`}>
       <NodeHeader
-        icon={<EditOutlined style={{ color: 'white', fontSize: '12px' }} />}
-        label={data.label || 'Capture'}
+        icon={<EditOutlined style={{ color: "white", fontSize: "12px" }} />}
+        label={data.label || "Capture"}
         color="#8b5cf6"
         isEditing={editing}
         editValue={label}
         onLabelChange={(e) => setLabel(e.target.value)}
         onLabelBlur={() => commitLabel(label)}
         onLabelKeyDown={(e) => {
-          if (e.key === 'Enter') {
+          if (e.key === "Enter") {
             commitLabel(label);
-          } else if (e.key === 'Escape') {
+          } else if (e.key === "Escape") {
             setEditing(false);
           }
         }}
         onDoubleClick={beginEdit}
       />
-      
+
       <div className={styles.content}>
-        {data.prompt && (
-          <div className={styles.prompt}>
-            {data.prompt}
-          </div>
-        )}
-        {captureMode === 'entities' ? (
+        {data.prompt && <div className={styles.prompt}>{data.prompt}</div>}
+        {captureMode === "entities" ? (
           <div className={styles.entityList}>
             {entities.length === 0 ? (
-              <div className={styles.entityEmpty}>Configure entities to capture</div>
+              <div className={styles.entityEmpty}>
+                Configure entities to capture
+              </div>
             ) : (
-              entities.map((entity) => (
+              entities.map((entity, index) => (
                 <div key={entity.id} className={styles.entityRow}>
-                  <div className={styles.entityName}>
-                    {entity.entity || 'Select entity'}
+                  <div className={styles.entityContent}>
+                    <div className={styles.entityName}>
+                      {entity.entity || "Select entity"}
+                    </div>
+                    <div className={styles.entityVariable}>
+                      {/* {entity.variable ? `{${entity.variable}}` : "No variable"} */}
+                    </div>
+                    {/* <div
+                      className={
+                        entity.required
+                          ? styles.entityRequired
+                          : styles.entityOptional
+                      }
+                    >
+                      {entity.required ? "Required" : "Optional"}
+                    </div> */}
                   </div>
-                  <div className={styles.entityVariable}>
-                    {entity.variable ? `{${entity.variable}}` : 'No variable'}
-                  </div>
-                  <div
-                    className={
-                      entity.required
-                        ? styles.entityRequired
-                        : styles.entityOptional
-                    }
-                  >
-                    {entity.required ? 'Required' : 'Optional'}
+                  {/* Entity handle positioned within the row */}
+                  <div className={styles.entityHandle}>
+                    <Handle
+                      type="source"
+                      position={Position.Right}
+                      id={`entity-${entity.id}`}
+                      className={`${styles.handle} ${styles["handle--entity"]}`}
+                    />
                   </div>
                 </div>
               ))
+            )}
+            {/* Exit path row - only show when exit path is enabled */}
+            {captureMode === "entities" && data.exitPathEnabled && (
+              <div className={styles.exitRow}>
+                <div className={styles.exitContent}>
+                  <div className={styles.exitName}>
+                    {data.exitPathLabel || "Exit path"}
+                  </div>
+                </div>
+                {/* Exit path handle positioned within the row */}
+                <div className={styles.exitHandle}>
+                  <Handle
+                    type="source"
+                    position={Position.Right}
+                    id="exit-path"
+                    className={`${styles.handle} ${styles["handle--exit"]}`}
+                  />
+                </div>
+              </div>
             )}
           </div>
         ) : (
           <div className={styles.row}>
             <div className={styles.kvLabel}>Variable:</div>
             <div className={styles.badgeMono}>
-              {data.variable || 'user_input'}
+              {data.variable || "user_input"}
             </div>
           </div>
         )}
         {data.validation && (
-          <div className={styles.validation}>
-            Validation: {data.validation}
-          </div>
+          <div className={styles.validation}>Validation: {data.validation}</div>
         )}
         {(data.listenForOtherTriggers ||
           data.noReply?.enabled ||
-          (captureMode === 'entities' && data.autoReprompt?.enabled) ||
-          (captureMode === 'entities' && data.exitPathEnabled)) && (
+          (captureMode === "entities" && data.autoReprompt?.enabled)) && (
           <div className={styles.metaRow}>
             {data.listenForOtherTriggers && (
               <span className={styles.metaBadge}>
@@ -186,15 +224,12 @@ export default function CaptureNode({ data, selected, id }: NodeProps<CaptureNod
             )}
             {data.noReply?.enabled && (
               <span className={styles.metaBadge}>
-                No reply{' '}
-                {data.noReply?.timeout ? `(${data.noReply.timeout}s)` : ''}
+                No reply{" "}
+                {data.noReply?.timeout ? `(${data.noReply.timeout}s)` : ""}
               </span>
             )}
-            {captureMode === 'entities' && data.autoReprompt?.enabled && (
+            {captureMode === "entities" && data.autoReprompt?.enabled && (
               <span className={styles.metaBadge}>Auto reprompt</span>
-            )}
-            {captureMode === 'entities' && data.exitPathEnabled && (
-              <span className={styles.metaBadge}>Exit path</span>
             )}
           </div>
         )}
@@ -204,15 +239,18 @@ export default function CaptureNode({ data, selected, id }: NodeProps<CaptureNod
       <Handle
         type="target"
         position={Position.Top}
-        className={`${styles.handle} ${styles['handle--top']}`}
+        className={`${styles.handle} ${styles["handle--top"]}`}
       />
-      
-      {/* Bottom handle (output) */}
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className={`${styles.handle} ${styles['handle--bottom']}`}
-      />
+
+      {/* Bottom handle (output) - only for reply mode or when no entities in entities mode */}
+      {(captureMode === "reply" ||
+        (captureMode === "entities" && entities.length === 0)) && (
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          className={`${styles.handle} ${styles["handle--bottom"]}`}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/voiceflow/nodes/ChoiceNode.module.scss
+++ b/src/components/voiceflow/nodes/ChoiceNode.module.scss
@@ -1,98 +1,104 @@
+@use "./variables" as *;
+
 .node {
-  background: #ffffff;
-  border: 1px solid #d1d9e0;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  width: 240px;
-  font-family: system-ui, -apple-system, sans-serif;
-  font-size: 14px;
-  color: #1f2328;
+  @extend %node-base;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 3px rgba(107, 114, 128, 0.12);
 
   &.selected {
-    border: 2px solid #1677ff;
-    box-shadow: 0 0 0 2px rgba(22, 119, 255, 0.2);
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.25);
   }
 }
 
-.header {
+.node__content {
+  padding: 14px 16px 16px;
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.node__prompt {
+  font-size: 12px;
+  line-height: 1.45;
+  color: #4c1d95;
+  background: #f3e8ff;
+  border: 1px solid #ddd6fe;
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.node__choiceList {
+  display: flex;
+  flex-direction: column;
   gap: 8px;
-  padding: 8px 10px;
-  border-bottom: 1px solid #f0f0f0;
-  background: #fafafa;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
 }
 
-.icon {
-  width: 18px;
-  height: 18px;
+.node__empty {
+  font-size: 12px;
+  color: #a855f7;
+  border: 1px dashed rgba(168, 85, 247, 0.4);
+  border-radius: 10px;
+  padding: 12px;
+  text-align: center;
+  background: #faf5ff;
+}
+
+.node__choiceRow {
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: center;
-  color: #1677ff;
-  background: #e6f4ff;
-  border-radius: 4px;
-
-  .anticon {
-    font-size: 12px;
-  }
+  gap: 12px;
+  border: 1px solid #e9d5ff;
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 8px 14px;
+  padding-right: 28px;
+  min-height: 36px;
+  box-shadow: 0 1px 2px rgba(79, 70, 229, 0.08);
+  overflow: visible;
 }
 
-.label {
-  font-size: 12px;
+.node__choiceLabel {
+  font-size: 13px;
   font-weight: 600;
-  color: #1f2937;
+  color: #312e81;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
 }
 
-.labelInput {
-  height: 22px;
+.node__choiceLabelPlaceholder {
+  color: #9ca3af;
+  font-weight: 500;
+  font-style: italic;
+}
+
+.node__choiceHandle {
+  position: absolute;
+  top: 50%;
+  right: -12px;
+  transform: translateY(-50%);
+}
+
+.node__more {
   font-size: 12px;
-  font-weight: 600;
-}
-
-.content {
-  padding: 10px;
-}
-
-.question {
-  font-size: 12px;
-  color: #374151;
-  margin-bottom: 8px;
-}
-
-.choiceItem {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 4px;
-}
-
-.choiceDot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #1677ff;
-}
-
-.choiceText {
-  font-size: 12px;
-  color: #374151;
-}
-
-.moreChoices {
-  font-size: 12px;
-  color: #8c8c8c;
+  color: #6b7280;
+  padding-left: 4px;
 }
 
 .handle {
+  position: absolute;
   width: 10px;
   height: 10px;
-  background: #1677ff;
   border-radius: 5px;
   border: 2px solid white;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+  z-index: 1;
+  background: #8b5cf6;
+  pointer-events: auto;
 
   &--top {
     top: -5px;
@@ -100,8 +106,13 @@
     transform: translateX(-50%);
   }
 
-  &--right {
-    right: -5px;
-    transform: translateY(-50%);
+  &--choice {
+    background: #6366f1;
   }
+}
+
+.handleInner {
+  opacity: 0;
+  width: 100%;
+  height: 100%;
 }

--- a/src/components/voiceflow/nodes/ChoiceNode.module.scss
+++ b/src/components/voiceflow/nodes/ChoiceNode.module.scss
@@ -54,7 +54,7 @@
   border-radius: 12px;
   background: #ffffff;
   padding: 8px 14px;
-  padding-right: 28px;
+  padding-right: 24px;
   min-height: 36px;
   box-shadow: 0 1px 2px rgba(79, 70, 229, 0.08);
   overflow: visible;
@@ -79,7 +79,7 @@
 .node__choiceHandle {
   position: absolute;
   top: 50%;
-  right: -12px;
+  right: -7px;
   transform: translateY(-50%);
 }
 

--- a/src/components/voiceflow/nodes/ChoiceNode.module.scss
+++ b/src/components/voiceflow/nodes/ChoiceNode.module.scss
@@ -79,7 +79,7 @@
 .node__choiceHandle {
   position: absolute;
   top: 50%;
-  right: -7px;
+  right: -12px;
   transform: translateY(-50%);
 }
 

--- a/src/components/voiceflow/nodes/ChoiceNode.tsx
+++ b/src/components/voiceflow/nodes/ChoiceNode.tsx
@@ -1,150 +1,192 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Handle, Position, NodeProps } from 'reactflow';
-import { ForkOutlined } from '@ant-design/icons';
-import { useAppDispatch } from '../../../store/hooks';
-import { updateNode } from '../../../store/slices/workflowSlice';
-import { NodeHeader } from './shared/NodeHeader';
-import styles from './ChoiceNode.module.scss';
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Handle, Position, NodeProps } from "reactflow";
+import { ForkOutlined } from "@ant-design/icons";
+import { useAppDispatch } from "../../../store/hooks";
+import { updateNode } from "../../../store/slices/workflowSlice";
+import NodeHeader from "./shared/NodeHeader";
+import styles from "./ChoiceNode.module.scss";
+
+interface NormalizedChoice {
+  id: string;
+  label: string;
+}
+
+const ensureChoiceShape = (choice: any, index: number): NormalizedChoice => {
+  const fallbackId = `choice-${index}`;
+
+  if (typeof choice === "string") {
+    const trimmed = choice.trim();
+    return {
+      id: fallbackId,
+      label: trimmed,
+    };
+  }
+
+  if (choice && typeof choice === "object") {
+    const choiceId =
+      typeof choice.id === "string" && choice.id.trim().length > 0
+        ? choice.id
+        : fallbackId;
+    const rawLabel =
+      typeof choice.label === "string"
+        ? choice.label
+        : typeof choice.text === "string"
+        ? choice.text
+        : "";
+    const rawIntent =
+      typeof choice.intent === "string"
+        ? choice.intent
+        : typeof choice.intentName === "string"
+        ? choice.intentName
+        : "";
+    const trimmedLabel = rawLabel.trim();
+    const trimmedIntent = rawIntent.trim();
+    const display = trimmedLabel || trimmedIntent;
+
+    return {
+      id: choiceId,
+      label: display,
+    };
+  }
+
+  return {
+    id: fallbackId,
+    label: "",
+  };
+};
+
+const normalizeChoices = (choices?: any[]): NormalizedChoice[] => {
+  const defaultChoices: NormalizedChoice[] = [
+    { id: "choice-0", label: "" },
+    { id: "choice-1", label: "" },
+  ];
+
+  if (!Array.isArray(choices)) {
+    return defaultChoices;
+  }
+
+  const mapped = choices.map((choice, index) => ensureChoiceShape(choice, index));
+
+  if (mapped.length === 0) {
+    return defaultChoices;
+  }
+
+  return mapped;
+};
 
 export default function ChoiceNode({ id, data, selected }: NodeProps<any>) {
   const dispatch = useAppDispatch();
   const [editing, setEditing] = useState<boolean>(!!data.__editingLabel);
-  const [label, setLabel] = useState<string>(data.label || '');
+  const [label, setLabel] = useState<string>(data.label || "Choice");
 
-  const normalizedChoices = useMemo(() => {
-    const fallback = [
-      { id: 'choice-0', label: 'Trigger' },
-      { id: 'choice-1', label: 'Trigger' },
-    ];
+  const normalizedChoices = useMemo(
+    () => normalizeChoices(data.choices),
+    [data.choices]
+  );
 
-    if (!Array.isArray(data.choices)) {
-      return fallback;
-    }
-
-    const mapped = data.choices.map((choice: any, index: number) => {
-      if (typeof choice === 'string') {
-        const trimmed = choice.trim();
-        return {
-          id: `choice-${index}`,
-          label: trimmed.length > 0 ? trimmed : 'Trigger',
-        };
-      }
-
-      if (choice && typeof choice === 'object') {
-        const choiceId =
-          typeof choice.id === 'string' ? choice.id : `choice-${index}`;
-        const rawLabel =
-          typeof choice.label === 'string'
-            ? choice.label
-            : typeof choice.text === 'string'
-            ? choice.text
-            : '';
-        const rawIntent =
-          typeof choice.intent === 'string'
-            ? choice.intent
-            : typeof choice.intentName === 'string'
-            ? choice.intentName
-            : '';
-        const trimmedLabel = (rawLabel || '').trim();
-        const trimmedIntent = (rawIntent || '').trim();
-        const display = trimmedLabel || trimmedIntent;
-        return {
-          id: choiceId,
-          label: display.length > 0 ? display : 'Trigger',
-        };
-      }
-
-      return { id: `choice-${index}`, label: 'Trigger' };
-    });
-
-    if (mapped.length === 0) {
-      return fallback;
-    }
-
-    return mapped;
-  }, [data.choices]);
+  const choicesToRender = normalizedChoices.slice(0, 4);
+  const remainingChoices = normalizedChoices.length - choicesToRender.length;
 
   useEffect(() => {
     setEditing(!!data.__editingLabel);
   }, [data.__editingLabel]);
 
-  const commitLabel = useCallback((next: string) => {
-    const trimmed = (next || '').trim();
-    dispatch(updateNode({ 
-      id, 
-      data: { 
-        ...data,
-        label: trimmed || 'Choice',
-        __editingLabel: false 
-      } 
-    }));
-    setEditing(false);
-  }, [dispatch, id, data]);
+  const commitLabel = useCallback(
+    (next: string) => {
+      const trimmed = (next || "").trim();
+      dispatch(
+        updateNode({
+          id,
+          data: {
+            ...data,
+            label: trimmed || data.label || "Choice",
+            __editingLabel: false,
+          },
+        })
+      );
+      setEditing(false);
+    },
+    [dispatch, id, data]
+  );
 
   const beginEdit = useCallback(() => {
     setEditing(true);
-    setLabel(data.label || '');
+    setLabel(data.label || "Choice");
   }, [data.label]);
 
   return (
-    <div className={`${styles.node} ${selected ? styles.selected : ''}`}>
+    <div className={`${styles.node} ${selected ? styles.selected : ""}`}>
       <NodeHeader
-        icon={<ForkOutlined style={{ color: 'white', fontSize: '12px' }} />}
-        label={data.label || 'Choice'}
+        icon={<ForkOutlined style={{ color: "white", fontSize: "12px" }} />}
+        label={data.label || "Choice"}
         color="#8b5cf6"
         isEditing={editing}
         editValue={label}
-        onLabelChange={(e) => setLabel(e.target.value)}
+        onLabelChange={(event) => setLabel(event.target.value)}
         onLabelBlur={() => commitLabel(label)}
-        onLabelKeyDown={(e) => {
-          if (e.key === 'Enter') {
+        onLabelKeyDown={(event) => {
+          if (event.key === "Enter") {
             commitLabel(label);
-          } else if (e.key === 'Escape') {
+          } else if (event.key === "Escape") {
             setEditing(false);
           }
         }}
         onDoubleClick={beginEdit}
       />
-      <div className={styles.content}>
+
+      <div className={styles.node__content}>
         {data.question && (
-          <div className={styles.question}>
-            {data.question}
-          </div>
+          <div className={styles.node__prompt}>{data.question}</div>
         )}
-          <div>
-            {normalizedChoices.slice(0, 3).map((choice, index: number) => (
-              <div key={index} className={styles.choiceItem}>
-                <div className={styles.choiceDot}></div>
-                <div className={styles.choiceText}>
-                  {choice.label || 'Trigger'}
+
+        <div className={styles.node__choiceList}>
+          {choicesToRender.length === 0 ? (
+            <div className={styles.node__empty}>No triggers configured yet</div>
+          ) : (
+            choicesToRender.map((choice, index) => {
+              const display = choice.label.trim();
+              const hasDisplay = display.length > 0;
+              return (
+                <div
+                  key={choice.id || index}
+                  className={styles.node__choiceRow}
+                >
+                  <span
+                    className={`${styles.node__choiceLabel} ${
+                      hasDisplay ? "" : styles.node__choiceLabelPlaceholder
+                    }`}
+                  >
+                    {hasDisplay ? display : "Select intent"}
+                  </span>
+                  <div className={styles.node__choiceHandle}>
+                    <div
+                      className={`${styles.handle} ${styles["handle--choice"]}`}
+                    >
+                      <Handle
+                        type="source"
+                        position={Position.Right}
+                        id={choice.id || `choice-${index}`}
+                        className={styles.handleInner}
+                      />
+                    </div>
+                  </div>
                 </div>
-              </div>
-            ))}
-          {normalizedChoices.length > 3 && (
-            <div className={styles.moreChoices}>
-              +{normalizedChoices.length - 3} more choices
-            </div>
+              );
+            })
+          )}
+          {remainingChoices > 0 && (
+            <div className={styles.node__more}>+{remainingChoices} more</div>
           )}
         </div>
       </div>
 
-      <Handle
-        type="target"
-        position={Position.Top}
-        className={`${styles.handle} ${styles['handle--top']}`}
-      />
-      {normalizedChoices.map((choice, index: number) => (
+      <div className={`${styles.handle} ${styles["handle--top"]}`}>
         <Handle
-          key={choice.id || index}
-          type="source"
-          position={Position.Right}
-          id={choice.id || `choice-${index}`}
-          className={`${styles.handle} ${styles['handle--right']}`}
-          style={{
-            top: `${30 + (index * 40)}%`,
-          }}
+          type="target"
+          position={Position.Top}
+          className={styles.handleInner}
         />
-      ))}
+      </div>
     </div>
   );
 }

--- a/src/components/voiceflow/nodes/ChoiceNode.tsx
+++ b/src/components/voiceflow/nodes/ChoiceNode.tsx
@@ -12,16 +12,24 @@ export default function ChoiceNode({ id, data, selected }: NodeProps<any>) {
   const [label, setLabel] = useState<string>(data.label || '');
 
   const normalizedChoices = useMemo(() => {
+    const fallback = [
+      { id: 'choice-0', label: 'Trigger' },
+      { id: 'choice-1', label: 'Trigger' },
+    ];
+
     if (!Array.isArray(data.choices)) {
-      return [
-        { id: 'choice-0', label: 'Choice A' },
-        { id: 'choice-1', label: 'Choice B' },
-      ];
+      return fallback;
     }
+
     const mapped = data.choices.map((choice: any, index: number) => {
       if (typeof choice === 'string') {
-        return { id: `choice-${index}`, label: choice };
+        const trimmed = choice.trim();
+        return {
+          id: `choice-${index}`,
+          label: trimmed.length > 0 ? trimmed : 'Trigger',
+        };
       }
+
       if (choice && typeof choice === 'object') {
         const choiceId =
           typeof choice.id === 'string' ? choice.id : `choice-${index}`;
@@ -31,20 +39,28 @@ export default function ChoiceNode({ id, data, selected }: NodeProps<any>) {
             : typeof choice.text === 'string'
             ? choice.text
             : '';
+        const rawIntent =
+          typeof choice.intent === 'string'
+            ? choice.intent
+            : typeof choice.intentName === 'string'
+            ? choice.intentName
+            : '';
         const trimmedLabel = (rawLabel || '').trim();
+        const trimmedIntent = (rawIntent || '').trim();
+        const display = trimmedLabel || trimmedIntent;
         return {
           id: choiceId,
-          label: trimmedLabel || rawLabel || `Choice ${index + 1}`,
+          label: display.length > 0 ? display : 'Trigger',
         };
       }
-      return { id: `choice-${index}`, label: `Choice ${index + 1}` };
+
+      return { id: `choice-${index}`, label: 'Trigger' };
     });
+
     if (mapped.length === 0) {
-      return [
-        { id: 'choice-0', label: 'Choice A' },
-        { id: 'choice-1', label: 'Choice B' },
-      ];
+      return fallback;
     }
+
     return mapped;
   }, [data.choices]);
 
@@ -95,15 +111,15 @@ export default function ChoiceNode({ id, data, selected }: NodeProps<any>) {
             {data.question}
           </div>
         )}
-        <div>
-          {normalizedChoices.slice(0, 3).map((choice, index: number) => (
-            <div key={index} className={styles.choiceItem}>
-              <div className={styles.choiceDot}></div>
-              <div className={styles.choiceText}>
-                {choice.label || `Choice ${index + 1}`}
+          <div>
+            {normalizedChoices.slice(0, 3).map((choice, index: number) => (
+              <div key={index} className={styles.choiceItem}>
+                <div className={styles.choiceDot}></div>
+                <div className={styles.choiceText}>
+                  {choice.label || 'Trigger'}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
           {normalizedChoices.length > 3 && (
             <div className={styles.moreChoices}>
               +{normalizedChoices.length - 3} more choices

--- a/src/store/slices/entitiesSlice.ts
+++ b/src/store/slices/entitiesSlice.ts
@@ -1,0 +1,91 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export interface EntityValue {
+  value: string;
+  synonyms?: string[];
+}
+
+export interface EntityDetail {
+  name: string;
+  dataType?: string;
+  values?: EntityValue[];
+  description?: string;
+}
+
+export interface EntitiesState {
+  list: string[];
+  details: Record<string, EntityDetail>;
+}
+
+const initialState: EntitiesState = {
+  list: ["OrderNumber", "Email", "Location"],
+  details: {},
+};
+
+const ensureUniqueSorted = (items: string[]) => {
+  const unique = Array.from(new Set(items.map((item) => item.trim()))).filter(Boolean);
+  unique.sort((a, b) => a.localeCompare(b));
+  return unique;
+};
+
+export const entitiesSlice = createSlice({
+  name: "entities",
+  initialState,
+  reducers: {
+    setEntities(state, action: PayloadAction<string[]>) {
+      state.list = ensureUniqueSorted(action.payload);
+    },
+    addEntity(state, action: PayloadAction<string>) {
+      const name = action.payload.trim();
+      if (!name) return;
+      if (!state.list.includes(name)) {
+        state.list.push(name);
+        state.list.sort((a, b) => a.localeCompare(b));
+      }
+    },
+    addEntityDetailed(state, action: PayloadAction<EntityDetail>) {
+      const payload = action.payload;
+      const name = (payload.name || "").trim();
+      if (!name) return;
+      if (!state.list.includes(name)) {
+        state.list.push(name);
+        state.list.sort((a, b) => a.localeCompare(b));
+      }
+
+      let normalizedValues: EntityValue[] | undefined;
+      if (Array.isArray(payload.values)) {
+        const collected: EntityValue[] = [];
+        payload.values.forEach((entry) => {
+          const primary = entry.value?.trim();
+          if (!primary) return;
+          const synonyms = Array.isArray(entry.synonyms)
+            ? entry.synonyms.map((synonym) => synonym.trim()).filter(Boolean)
+            : undefined;
+          const normalized: EntityValue = {
+            value: primary,
+            ...(synonyms && synonyms.length > 0 ? { synonyms } : {}),
+          };
+          collected.push(normalized);
+        });
+        normalizedValues = collected.length > 0 ? collected : undefined;
+      }
+
+      state.details[name] = {
+        ...payload,
+        name,
+        dataType: payload.dataType || undefined,
+        description: payload.description?.trim() || undefined,
+        values: normalizedValues,
+      };
+    },
+    removeEntity(state, action: PayloadAction<string>) {
+      const target = action.payload;
+      state.list = state.list.filter((entity) => entity !== target);
+      delete state.details[target];
+    },
+  },
+});
+
+export const { setEntities, addEntity, addEntityDetailed, removeEntity } =
+  entitiesSlice.actions;
+export default entitiesSlice.reducer;

--- a/src/store/slices/entitiesSlice.ts
+++ b/src/store/slices/entitiesSlice.ts
@@ -1,5 +1,10 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
+export interface EntityDataType {
+  label: string;
+  value: string;
+}
+
 export interface EntityValue {
   value: string;
   synonyms?: string[];
@@ -15,15 +20,30 @@ export interface EntityDetail {
 export interface EntitiesState {
   list: string[];
   details: Record<string, EntityDetail>;
+  dataTypes: EntityDataType[];
 }
 
 const initialState: EntitiesState = {
   list: ["OrderNumber", "Email", "Location"],
   details: {},
+  dataTypes: [
+    { label: "Custom", value: "custom" },
+    { label: "Number", value: "number" },
+    { label: "Email", value: "email" },
+    { label: "Name", value: "name" },
+    { label: "Age", value: "age" },
+    { label: "Url", value: "url" },
+    { label: "Phone", value: "phone" },
+    { label: "Date", value: "date" },
+    { label: "Time", value: "time" },
+    { label: "Location", value: "location" },
+  ],
 };
 
 const ensureUniqueSorted = (items: string[]) => {
-  const unique = Array.from(new Set(items.map((item) => item.trim()))).filter(Boolean);
+  const unique = Array.from(new Set(items.map((item) => item.trim()))).filter(
+    Boolean
+  );
   unique.sort((a, b) => a.localeCompare(b));
   return unique;
 };
@@ -83,9 +103,17 @@ export const entitiesSlice = createSlice({
       state.list = state.list.filter((entity) => entity !== target);
       delete state.details[target];
     },
+    setDataTypes(state, action: PayloadAction<EntityDataType[]>) {
+      state.dataTypes = action.payload;
+    },
   },
 });
 
-export const { setEntities, addEntity, addEntityDetailed, removeEntity } =
-  entitiesSlice.actions;
+export const {
+  setEntities,
+  addEntity,
+  addEntityDetailed,
+  removeEntity,
+  setDataTypes,
+} = entitiesSlice.actions;
 export default entitiesSlice.reducer;

--- a/src/store/slices/intentsSlice.ts
+++ b/src/store/slices/intentsSlice.ts
@@ -5,6 +5,7 @@ export interface IntentDetail {
   description?: string;
   utterances?: string[];
   color?: string;
+  requiredEntities?: string[];
 }
 
 export interface IntentsState {
@@ -48,6 +49,11 @@ export const intentsSlice = createSlice({
         description: payload.description?.trim() || undefined,
         utterances: Array.isArray(payload.utterances)
           ? payload.utterances.filter((item) => !!item && item.trim().length > 0)
+          : undefined,
+        requiredEntities: Array.isArray(payload.requiredEntities)
+          ? payload.requiredEntities
+              .map((entry) => entry.trim())
+              .filter((entry) => entry.length > 0)
           : undefined,
       };
     },

--- a/src/store/slices/intentsSlice.ts
+++ b/src/store/slices/intentsSlice.ts
@@ -1,0 +1,63 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export interface IntentDetail {
+  name: string;
+  description?: string;
+  utterances?: string[];
+  color?: string;
+}
+
+export interface IntentsState {
+  list: string[];
+  details: Record<string, IntentDetail>;
+}
+
+const initialState: IntentsState = {
+  list: ["Default Intent", "Fallback Intent", "Escalate"],
+  details: {},
+};
+
+export const intentsSlice = createSlice({
+  name: "intents",
+  initialState,
+  reducers: {
+    setIntents(state, action: PayloadAction<string[]>) {
+      const unique = Array.from(new Set(action.payload.map((item) => item.trim()))).filter(Boolean);
+      unique.sort((a, b) => a.localeCompare(b));
+      state.list = unique;
+    },
+    addIntent(state, action: PayloadAction<string>) {
+      const name = action.payload.trim();
+      if (!name) return;
+      if (!state.list.includes(name)) {
+        state.list.push(name);
+        state.list.sort((a, b) => a.localeCompare(b));
+      }
+    },
+    addIntentDetailed(state, action: PayloadAction<IntentDetail>) {
+      const payload = action.payload;
+      const name = (payload.name || "").trim();
+      if (!name) return;
+      if (!state.list.includes(name)) {
+        state.list.push(name);
+        state.list.sort((a, b) => a.localeCompare(b));
+      }
+      state.details[name] = {
+        ...payload,
+        name,
+        description: payload.description?.trim() || undefined,
+        utterances: Array.isArray(payload.utterances)
+          ? payload.utterances.filter((item) => !!item && item.trim().length > 0)
+          : undefined,
+      };
+    },
+    removeIntent(state, action: PayloadAction<string>) {
+      const target = action.payload;
+      state.list = state.list.filter((intent) => intent !== target);
+      delete state.details[target];
+    },
+  },
+});
+
+export const { setIntents, addIntent, addIntentDetailed, removeIntent } = intentsSlice.actions;
+export default intentsSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -7,6 +7,7 @@ import conditionBuilderReducer from "./slices/conditionBuilderSlice";
 import promptsReducer from "./slices/promptsSlice";
 import knowledgeBaseReducer from "../lib/knowledge-base/knowledgeBaseSlice";
 import intentsReducer from "./slices/intentsSlice";
+import entitiesReducer from "./slices/entitiesSlice";
 
 export const store = configureStore({
   reducer: {
@@ -18,6 +19,7 @@ export const store = configureStore({
     conditionBuilder: conditionBuilderReducer,
     prompts: promptsReducer,
     knowledgeBase: knowledgeBaseReducer,
+    entities: entitiesReducer,
   },
 });
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -6,6 +6,7 @@ import variablesReducer from "./slices/variablesSlice";
 import conditionBuilderReducer from "./slices/conditionBuilderSlice";
 import promptsReducer from "./slices/promptsSlice";
 import knowledgeBaseReducer from "../lib/knowledge-base/knowledgeBaseSlice";
+import intentsReducer from "./slices/intentsSlice";
 
 export const store = configureStore({
   reducer: {
@@ -13,6 +14,7 @@ export const store = configureStore({
     ui: uiReducer,
     userInteraction: userInteractionReducer,
     variables: variablesReducer,
+    intents: intentsReducer,
     conditionBuilder: conditionBuilderReducer,
     prompts: promptsReducer,
     knowledgeBase: knowledgeBaseReducer,


### PR DESCRIPTION
## Summary
- add a reusable `IntentPicker` component and Redux slice for managing intent data
- enhance the choice properties panel with a popover editor for intent, button label, and reprompt settings backed by the new picker
- connect go-to-intent button actions and default choice data/rendering to the intent picker flow

## Testing
- npm run build *(fails: project still references Next.js UI dependencies that are not installed in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e0025a945c8327a28dd4657bf5cf2f