### PR TITLE
Fix prompt variant persistence and fullscreen editor

### DIFF
--- a/src/components/voiceflow/PropertiesPanel.module.scss
+++ b/src/components/voiceflow/PropertiesPanel.module.scss
@@ -983,6 +983,15 @@
 
 .promptReturnMessage {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.promptReturnMessageLabel {
+  font-size: 12px;
+  font-weight: 500;
+  color: #64748b;
 }
 
 .promptReturnTextarea {

--- a/src/components/voiceflow/PropertiesPanel.tsx
+++ b/src/components/voiceflow/PropertiesPanel.tsx
@@ -4708,7 +4708,9 @@ export default function PropertiesPanel({
               message: entry.message.trim(),
             };
           })
-          .filter((entry) => entry.message.length > 0);
+          .filter(
+            (entry) => entry.value.length > 0 || entry.message.length > 0
+          );
 
         nextVariant = {
           id: editingVariantId ?? nanoid(),
@@ -4848,7 +4850,7 @@ export default function PropertiesPanel({
 
     const openVariantFullScreenEditor = () => {
       setShowExpressionEditor(false);
-      setShowVariantFullScreenEditor(true);
+      setTimeout(() => setShowVariantFullScreenEditor(true), 0);
     };
 
     const handleRemoveVariant = (variantId: string) => {
@@ -5269,6 +5271,25 @@ export default function PropertiesPanel({
                                             }
                                             className={styles.promptReturnRemoveButton}
                                             aria-label="Remove return value"
+                                          />
+                                        </div>
+                                        <div className={styles.promptReturnMessage}>
+                                          <Typography.Text
+                                            type="secondary"
+                                            className={styles.promptReturnMessageLabel}
+                                          >
+                                            Message
+                                          </Typography.Text>
+                                          <RichTextEditor
+                                            value={returnValue.message}
+                                            onChange={(value) =>
+                                              handleUpdatePromptReturnValue(
+                                                returnValue.id,
+                                                { message: value }
+                                              )
+                                            }
+                                            placeholder="Enter the message to send when this value matches"
+                                            className={styles.promptReturnTextarea}
                                           />
                                         </div>
                                       </div>


### PR DESCRIPTION
## Summary
- preserve prompt variant return values by retaining empty message entries and trimming user input safely
- add a dedicated message editor for each prompt return value and align the styling of the prompt return section
- ensure the expression editor fullscreen action defers opening until after the popover closes to consistently launch the modal

## Testing
- npm run lint *(fails: project uses the new flat ESLint config so the `--ext` flag in the script is invalid)*
- npm run build *(fails: repository is missing several optional dependencies such as Next.js, Radix UI, and class-variance-authority)*

------
https://chatgpt.com/codex/tasks/task_e_68e231ae59a08327991b980c6c428ab2